### PR TITLE
fix: scan sovereign tenant cron by domain

### DIFF
--- a/bin/scan-cron.php
+++ b/bin/scan-cron.php
@@ -1,18 +1,10 @@
 <?php
 /**
- * Execute one or more jobs in a fresh WordPress environment.
+ * Scan a site's WP-Cron array in a fresh WordPress environment.
  *
- * Spawned by worker.php as a subprocess. Bootstraps WordPress with the correct
- * site domain so all per-site plugins are loaded and DB tables are correct.
- * Accepts a single payload (legacy) or an array of payloads for batch execution.
- *
- * Usage:
- *   php execute-job.php --stdin              (reads JSON from stdin)
- *   php execute-job.php <base64-json>        (legacy)
- *
- * Exit codes:
- *   0 = all jobs succeeded
- *   1 = one or more jobs failed
+ * Used by the long-running worker for sovereign tenants. Those tenants must be
+ * bootstrapped by domain so db-config.php selects the tenant DB and wp_ table
+ * prefix before WordPress loads.
  */
 
 // --- Parse payload from stdin or CLI arg ---
@@ -21,33 +13,24 @@ if (($argv[1] ?? '') === '--stdin') {
 } else {
     $raw = base64_decode($argv[1] ?? '', true);
 }
+
 if (!$raw) {
     fwrite(STDERR, "Missing or invalid payload.\n");
     exit(1);
 }
-$payload_data = json_decode($raw, true);
-if (!is_array($payload_data)) {
+
+$payload = json_decode($raw, true);
+if (!is_array($payload)) {
     fwrite(STDERR, "Invalid JSON payload.\n");
     exit(1);
 }
 
-// Normalize: single payload (has 'hook' key) -> wrap in array
-$payloads = isset($payload_data['hook']) ? [$payload_data] : $payload_data;
-if (empty($payloads)) {
-    fwrite(STDERR, "Empty payload array.\n");
-    exit(1);
-}
-
-$payload = $payloads[0];
-
 // --- Load QueueWorker classes ---
-// 1. Load plugin's own autoloader (classmap with all QueueWorker classes)
 $plugin_autoload = dirname(__DIR__) . '/vendor/autoload.php';
 if (file_exists($plugin_autoload)) {
     require_once $plugin_autoload;
 }
 
-// 2. Walk up from plugin root to find site autoloader (Bedrock: has Dotenv, etc.)
 $site_autoload = null;
 $search = dirname(__DIR__);
 for ($i = 0; $i < 10; $i++) {
@@ -57,6 +40,7 @@ for ($i = 0; $i < 10; $i++) {
         break;
     }
 }
+
 if ($site_autoload) {
     require_once $site_autoload;
 }
@@ -67,18 +51,16 @@ if (!class_exists('QueueWorker\\Config')) {
 }
 
 use QueueWorker\Bootstrap;
-use QueueWorker\Job_Executor;
-use QueueWorker\Job_Log;
+use QueueWorker\Job_Payload;
 
-// --- Discover WordPress and load environment ---
 $site_root = $site_autoload ? dirname($site_autoload, 2) : dirname(__DIR__);
 Bootstrap::load_dotenv($site_root);
 $wp_load = Bootstrap::discover_wp_load(__DIR__);
 
-// --- Bootstrap WordPress with the target site's domain ---
 $domain = parse_url($payload['site_url'] ?? '', PHP_URL_HOST);
 if (!$domain) {
-    $domain = getenv('DOMAIN_CURRENT_SITE') ?: 'localhost';
+    fwrite(STDERR, "Missing site_url host.\n");
+    exit(1);
 }
 
 $_SERVER['HTTP_HOST']      = $domain;
@@ -89,26 +71,52 @@ $_SERVER['HTTPS']          = 'on';
 $_SERVER['REQUEST_METHOD'] = 'GET';
 
 define('QUEUE_WORKER_RUNNING', true);
-if (!defined('DOING_CRON')) {
-    define('DOING_CRON', true);
-}
 
 require_once $wp_load;
 
-// Ensure we're on the correct blog
 $site_id = (int) ($payload['site_id'] ?? get_current_blog_id());
 $is_sovereign_tenant = (defined('WU_MT_SOVEREIGN_TENANT') && (int) WU_MT_SOVEREIGN_TENANT === $site_id)
-    || qw_payload_matches_sovereign_registry($site_id, $domain);
+    || qw_scan_payload_matches_sovereign_registry($site_id, $domain);
 if (!$is_sovereign_tenant && $site_id !== get_current_blog_id()) {
     switch_to_blog($site_id);
 }
 
-Job_Log::ensure_table();
+wp_cache_delete('cron', 'options');
+wp_cache_delete('alloptions', 'options');
 
-// --- Execute jobs ---
-exit((new Job_Executor($site_id))->run($payloads));
+$bypass_hooks = [
+    'wp_version_check',
+    'wp_update_plugins',
+    'wp_update_themes',
+    'action_scheduler_run_queue',
+    'action_scheduler_run_cleanup',
+];
 
-function qw_payload_matches_sovereign_registry(int $site_id, string $domain): bool
+$payloads = [];
+$crons = _get_cron_array();
+if (is_array($crons)) {
+    foreach ($crons as $timestamp => $hooks) {
+        if (!is_array($hooks)) {
+            continue;
+        }
+        foreach ($hooks as $hook => $events) {
+            if (in_array($hook, $bypass_hooks, true)) {
+                continue;
+            }
+            foreach ($events as $event) {
+                $event_obj = (object) array_merge($event, [
+                    'hook'      => $hook,
+                    'timestamp' => $timestamp,
+                ]);
+                $payloads[] = json_decode(Job_Payload::from_cron_event($event_obj)->to_json(), true);
+            }
+        }
+    }
+}
+
+echo json_encode($payloads);
+
+function qw_scan_payload_matches_sovereign_registry(int $site_id, string $domain): bool
 {
     if (!defined('WP_CONTENT_DIR') || $domain === '') {
         return false;

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -62,6 +62,7 @@ $wp_load = Bootstrap::discover_wp_load(__DIR__);
 $socket_path    = Config::socket_path();
 $primary_domain = getenv('DOMAIN_CURRENT_SITE') ?: 'localhost';
 $execute_script = __DIR__ . '/execute-job.php';
+$scan_script    = __DIR__ . '/scan-cron.php';
 
 // --- Clean up stale socket file ---
 if (file_exists($socket_path)) {
@@ -78,7 +79,7 @@ $worker = new Worker('unix://' . $socket_path);
 $worker->count = Config::worker_count();
 $worker->name  = 'the-perfect-wp-cron';
 
-$process = new Worker_Process($wp_load, $primary_domain, $execute_script);
+$process = new Worker_Process($wp_load, $primary_domain, $execute_script, $scan_script);
 
 $worker->onWorkerStart = [$process, 'on_worker_start'];
 $worker->onMessage     = [$process, 'on_message'];

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -19,6 +19,16 @@ class Config
         return (int) self::get('QUEUE_WORKER_MAX_CONCURRENT', 1);
     }
 
+    public static function action_scheduler_max_concurrent(): int
+    {
+        return (int) self::get('QUEUE_WORKER_AS_MAX_CONCURRENT', 1);
+    }
+
+    public static function action_scheduler_max_batch_size(): int
+    {
+        return (int) self::get('QUEUE_WORKER_AS_MAX_BATCH_SIZE', 10);
+    }
+
     public static function max_batch_size(): int
     {
         return (int) self::get('QUEUE_WORKER_MAX_BATCH_SIZE', 50);

--- a/src/class-job-payload.php
+++ b/src/class-job-payload.php
@@ -16,7 +16,7 @@ class Job_Payload
 
     public function __construct(array $data = [])
     {
-        $this->site_id   = $data['site_id'] ?? get_current_blog_id();
+        $this->site_id   = $data['site_id'] ?? self::current_site_id();
         $this->site_url  = $data['site_url'] ?? get_site_url();
         $this->hook      = $data['hook'] ?? '';
         $this->args      = $data['args'] ?? [];
@@ -60,7 +60,7 @@ class Job_Payload
         }
 
         return new self([
-            'site_id'   => get_current_blog_id(),
+            'site_id'   => self::current_site_id(),
             'site_url'  => get_site_url(),
             'hook'      => $event->hook,
             'args'      => $event->args ?? [],
@@ -88,7 +88,7 @@ class Job_Payload
         $timestamp = $next_date ? $next_date->getTimestamp() : time();
 
         return new self([
-            'site_id'   => get_current_blog_id(),
+            'site_id'   => self::current_site_id(),
             'site_url'  => get_site_url(),
             'hook'      => $action->get_hook(),
             'args'      => $action->get_args(),
@@ -101,12 +101,33 @@ class Job_Payload
     public function tracking_key(): string
     {
         return sprintf(
-            '%s:%d:%s:%s:%d',
+            '%s:%d:%s:%s:%s:%d',
             $this->source,
             $this->site_id,
+            md5($this->site_url),
             $this->hook,
             md5(serialize($this->args)),
             $this->timestamp
         );
+    }
+
+    private static function current_site_id(): int
+    {
+        if (defined('WU_MT_SOVEREIGN_TENANT')) {
+            return (int) WU_MT_SOVEREIGN_TENANT;
+        }
+
+        $host = strtolower(trim((string) ($_SERVER['HTTP_HOST'] ?? '')));
+        if ($host !== '' && defined('WP_CONTENT_DIR')) {
+            $path = WP_CONTENT_DIR . '/site-registry.data.json';
+            if (is_readable($path)) {
+                $data = json_decode((string) file_get_contents($path), true);
+                if (is_array($data) && isset($data['domain_index'][$host])) {
+                    return (int) $data['domain_index'][$host];
+                }
+            }
+        }
+
+        return get_current_blog_id();
     }
 }

--- a/src/class-worker-process.php
+++ b/src/class-worker-process.php
@@ -22,6 +22,9 @@ class Worker_Process
     /** @var string Absolute path to execute-job.php */
     private string $execute_script;
 
+    /** @var string Absolute path to scan-cron.php */
+    private string $scan_script;
+
     // --- Configuration ---
     private int $max_concurrent;
     private int $max_batch_size;
@@ -43,11 +46,12 @@ class Worker_Process
     private int $running_jobs = 0;
     private int $start_time;
 
-    public function __construct(string $wp_load, string $primary_domain, string $execute_script)
+    public function __construct(string $wp_load, string $primary_domain, string $execute_script, string $scan_script = '')
     {
         $this->wp_load        = $wp_load;
         $this->primary_domain = $primary_domain;
         $this->execute_script = $execute_script;
+        $this->scan_script    = $scan_script;
 
         $this->max_concurrent  = Config::max_concurrent();
         $this->max_batch_size  = Config::max_batch_size();
@@ -364,8 +368,14 @@ class Worker_Process
     private function rescan_all_jobs(): void
     {
         $sites = get_sites(['number' => 0, 'fields' => 'ids']);
+        $sovereign_sites = $this->sovereign_site_entries();
 
         foreach ($sites as $site_id) {
+            $site_id = (int) $site_id;
+            if (isset($sovereign_sites[$site_id])) {
+                continue;
+            }
+
             switch_to_blog($site_id);
 
             // Flush stale object cache so we read fresh data from DB.
@@ -418,6 +428,127 @@ class Worker_Process
 
             restore_current_blog();
         }
+
+        foreach ($sovereign_sites as $site_id => $entry) {
+            $this->rescan_sovereign_site_jobs((int) $site_id, $entry);
+        }
+    }
+
+    /**
+     * Load sovereign tenant entries from the generated multi-tenancy registry.
+     *
+     * Sovereign tenants must be scanned in a fresh PHP process bootstrapped with
+     * their own domain. switch_to_blog() in the root worker would target
+     * wp_<blog_id>_* tables inside the tenant DB, but sovereign tenant tables use
+     * the tenant-local wp_ prefix.
+     *
+     * @return array<int, array>
+     */
+    private function sovereign_site_entries(): array
+    {
+        if (!defined('WP_CONTENT_DIR')) {
+            return [];
+        }
+
+        $path = WP_CONTENT_DIR . '/site-registry.data.json';
+        if (!is_readable($path)) {
+            return [];
+        }
+
+        $json = file_get_contents($path);
+        $data = json_decode($json ?: '', true);
+        if (!is_array($data) || empty($data['sites']) || !is_array($data['sites'])) {
+            return [];
+        }
+
+        $entries = [];
+        foreach ($data['sites'] as $site_id => $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+            if (($entry['isolation_model'] ?? '') !== 'sovereign') {
+                continue;
+            }
+            if (($entry['status'] ?? 'active') !== 'active') {
+                continue;
+            }
+            if (empty($entry['domains']) || !is_array($entry['domains'])) {
+                continue;
+            }
+
+            $entries[(int) $site_id] = $entry;
+        }
+
+        return $entries;
+    }
+
+    private function rescan_sovereign_site_jobs(int $site_id, array $entry): void
+    {
+        if ($this->scan_script === '' || !file_exists($this->scan_script)) {
+            Worker::log(sprintf('[RESCAN][SOVEREIGN][ERROR] Missing scan script for site %d', $site_id));
+            return;
+        }
+
+        $site_url = $this->site_url_from_registry_entry($entry);
+        if ($site_url === '') {
+            Worker::log(sprintf('[RESCAN][SOVEREIGN][ERROR] Missing tenant domain for site %d', $site_id));
+            return;
+        }
+
+        $cmd = sprintf('php %s --stdin', escapeshellarg($this->scan_script));
+        $process = proc_open($cmd, [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ], $pipes);
+
+        if (!is_resource($process)) {
+            Worker::log(sprintf('[RESCAN][SOVEREIGN][ERROR] Failed to spawn scan for site %d', $site_id));
+            return;
+        }
+
+        fwrite($pipes[0], json_encode([
+            'site_id'  => $site_id,
+            'site_url' => $site_url,
+        ]));
+        fclose($pipes[0]);
+
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit_code = proc_close($process);
+
+        if ($exit_code !== 0) {
+            $message = trim((string) $stderr);
+            Worker::log(sprintf('[RESCAN][SOVEREIGN][FAIL] Site %d scan failed: %s', $site_id, $message));
+            return;
+        }
+
+        $payloads = json_decode((string) $stdout, true);
+        if (!is_array($payloads)) {
+            Worker::log(sprintf('[RESCAN][SOVEREIGN][FAIL] Site %d scan returned invalid JSON', $site_id));
+            return;
+        }
+
+        foreach ($payloads as $payload_data) {
+            if (!is_array($payload_data)) {
+                continue;
+            }
+            $this->schedule_timer(new Job_Payload($payload_data));
+        }
+    }
+
+    private function site_url_from_registry_entry(array $entry): string
+    {
+        foreach ($entry['domains'] ?? [] as $domain) {
+            $domain = trim((string) $domain);
+            if ($domain !== '') {
+                return 'https://' . $domain . '/';
+            }
+        }
+
+        return '';
     }
 
     /**

--- a/src/class-worker-process.php
+++ b/src/class-worker-process.php
@@ -28,6 +28,8 @@ class Worker_Process
     // --- Configuration ---
     private int $max_concurrent;
     private int $max_batch_size;
+    private int $as_max_concurrent;
+    private int $as_max_batch_size;
     private int $batch_timeout;
     private int $rescan_interval;
     private int $memory_limit;
@@ -37,11 +39,14 @@ class Worker_Process
     /** @var array<string, int> tracking_key => timer_id */
     private array $pending_timers = [];
 
-    /** @var list<array{process: resource, pipes: array, payloads: list<Job_Payload>, started: int, stdout: string, stderr: string}> */
+    /** @var list<array{process: resource, pipes: array, payloads: list<Job_Payload>, started: int, stdout: string, stderr: string, lane: string}> */
     private array $running_processes = [];
 
     /** @var array<int, list<Job_Payload>> site_id => [payload, ...] */
     private array $pending_batch = [];
+
+    /** @var array<int, list<Job_Payload>> site_id => [payload, ...] */
+    private array $pending_as_batch = [];
 
     private int $running_jobs = 0;
     private int $start_time;
@@ -55,6 +60,8 @@ class Worker_Process
 
         $this->max_concurrent  = Config::max_concurrent();
         $this->max_batch_size  = Config::max_batch_size();
+        $this->as_max_concurrent = Config::action_scheduler_max_concurrent();
+        $this->as_max_batch_size = Config::action_scheduler_max_batch_size();
         $this->batch_timeout   = Config::batch_timeout();
         $this->rescan_interval = Config::rescan_interval();
         $this->memory_limit    = Config::memory_limit();
@@ -84,7 +91,8 @@ class Worker_Process
             Job_Log::ensure_table();
         }
 
-        // Batch flush timer — every 1 second
+        // Batch flush timer — every 1 second. Action Scheduler gets its own
+        // lane so due AS jobs are not starved behind noisy WP-Cron batches.
         Timer::add(1, fn() => $this->flush_batches());
 
         // Subprocess polling timer — every 0.5 seconds
@@ -172,6 +180,11 @@ class Worker_Process
         $key = $payload->tracking_key();
         unset($this->pending_timers[$key]);
 
+        if ($payload->source === 'action_scheduler') {
+            $this->execute_action_scheduler_job($payload);
+            return;
+        }
+
         // Check concurrency limit before claiming
         if (count($this->running_processes) >= $this->max_concurrent) {
             // Re-schedule with 2s delay
@@ -191,9 +204,35 @@ class Worker_Process
     }
 
     /**
+     * Fired by timer when an Action Scheduler job is due.
+     *
+     * Action Scheduler gets a dedicated lane instead of sharing the normal
+     * WP-Cron concurrency budget. This preserves exact scheduling for urgent
+     * AS work (checkout pending-site publish, domain stages, billing jobs)
+     * even when the worker is draining many recurring cron events.
+     */
+    private function execute_action_scheduler_job(Job_Payload $payload): void
+    {
+        $key = $payload->tracking_key();
+
+        if ($this->running_process_count('action_scheduler') >= $this->as_max_concurrent) {
+            $timer_id = Timer::add(1, fn($p) => $this->execute_action_scheduler_job($p), [$payload], false);
+            $this->pending_timers[$key] = $timer_id;
+            return;
+        }
+
+        $lock_key = 'qw_' . substr(md5($key), 0, 40);
+        if (!$this->claim_job($lock_key)) {
+            return;
+        }
+
+        $this->pending_as_batch[$payload->site_id][] = $payload;
+    }
+
+    /**
      * Spawn a subprocess to execute a batch of jobs (all same site).
      */
-    private function spawn_batch(array $payloads, int $worker_id): void
+    private function spawn_batch(array $payloads, int $worker_id, string $lane = 'wp_cron'): void
     {
         $json_array = array_map(
             fn($p) => json_decode($p->to_json(), true),
@@ -232,12 +271,14 @@ class Worker_Process
             'started'  => time(),
             'stdout'   => '',
             'stderr'   => '',
+            'lane'     => $lane,
         ];
 
         $hooks = array_map(fn($p) => $p->hook, $payloads);
         Worker::log(sprintf(
-            '[W%d][SPAWN] Batch: %d jobs on site %d (pid %d, %d running): %s',
+            '[W%d][SPAWN][%s] Batch: %d jobs on site %d (pid %d, %d running): %s',
             $worker_id,
+            $lane,
             count($payloads),
             $payloads[0]->site_id,
             proc_get_status($process)['pid'] ?? 0,
@@ -251,6 +292,8 @@ class Worker_Process
      */
     private function flush_batches(): void
     {
+        $this->flush_action_scheduler_batches();
+
         foreach ($this->pending_batch as $site_id => $payloads) {
             if (empty($payloads)) {
                 unset($this->pending_batch[$site_id]);
@@ -266,6 +309,38 @@ class Worker_Process
                 unset($this->pending_batch[$site_id]);
             }
         }
+    }
+
+    /**
+     * Flush pending Action Scheduler batches before normal WP-Cron batches.
+     */
+    private function flush_action_scheduler_batches(): void
+    {
+        foreach ($this->pending_as_batch as $site_id => $payloads) {
+            if (empty($payloads)) {
+                unset($this->pending_as_batch[$site_id]);
+                continue;
+            }
+            if ($this->running_process_count('action_scheduler') >= $this->as_max_concurrent) {
+                break;
+            }
+            $batch = array_splice($this->pending_as_batch[$site_id], 0, $this->as_max_batch_size);
+            $this->spawn_batch($batch, 0, 'action_scheduler');
+            if (empty($this->pending_as_batch[$site_id])) {
+                unset($this->pending_as_batch[$site_id]);
+            }
+        }
+    }
+
+    private function running_process_count(string $lane): int
+    {
+        $count = 0;
+        foreach ($this->running_processes as $proc) {
+            if (($proc['lane'] ?? 'wp_cron') === $lane) {
+                $count++;
+            }
+        }
+        return $count;
     }
 
     /**
@@ -370,6 +445,15 @@ class Worker_Process
         $sites = get_sites(['number' => 0, 'fields' => 'ids']);
         $sovereign_sites = $this->sovereign_site_entries();
 
+        $current_blog_id = get_current_blog_id();
+
+        // Action Scheduler stores its tables at the network/base prefix in
+        // this multisite. Scanning it while switched to sovereign subsites
+        // makes Action Scheduler look for missing per-site AS tables and also
+        // schedules duplicate timers with different site IDs. Scan AS once in
+        // the current/root context, then scan WP-Cron per site below.
+        $this->rescan_action_scheduler_jobs();
+
         foreach ($sites as $site_id) {
             $site_id = (int) $site_id;
             if (isset($sovereign_sites[$site_id])) {
@@ -411,26 +495,15 @@ class Worker_Process
                     }
                 }
             }
-
-            // Scan Action Scheduler
-            if (function_exists('as_get_scheduled_actions')) {
-                $actions = as_get_scheduled_actions([
-                    'status'   => \ActionScheduler_Store::STATUS_PENDING,
-                    'per_page' => 500,
-                ]);
-                foreach ($actions as $action_id => $action) {
-                    $payload = Job_Payload::from_as_action($action_id);
-                    if ($payload) {
-                        $this->schedule_timer($payload);
-                    }
-                }
-            }
-
             restore_current_blog();
         }
 
         foreach ($sovereign_sites as $site_id => $entry) {
             $this->rescan_sovereign_site_jobs((int) $site_id, $entry);
+        }
+
+        if ($current_blog_id !== get_current_blog_id()) {
+            switch_to_blog($current_blog_id);
         }
     }
 
@@ -551,6 +624,24 @@ class Worker_Process
         return '';
     }
 
+    private function rescan_action_scheduler_jobs(): void
+    {
+        if (!function_exists('as_get_scheduled_actions')) {
+            return;
+        }
+
+        $actions = as_get_scheduled_actions([
+            'status'   => \ActionScheduler_Store::STATUS_PENDING,
+            'per_page' => 500,
+        ]);
+        foreach ($actions as $action_id => $action) {
+            $payload = Job_Payload::from_as_action($action_id);
+            if ($payload) {
+                $this->schedule_timer($payload);
+            }
+        }
+    }
+
     /**
      * Atomically claim a job via INSERT IGNORE into the lock table.
      */
@@ -599,6 +690,7 @@ class Worker_Process
                         'site_id' => $site_id,
                         'count'   => $count,
                         'elapsed' => time() - $proc['started'],
+                        'lane'    => $proc['lane'] ?? 'wp_cron',
                     ];
                 }
 
@@ -607,7 +699,9 @@ class Worker_Process
                     'uptime'          => sprintf('%dh %dm %ds', $hours, $mins, $secs),
                     'uptime_seconds'  => $uptime,
                     'pending_timers'  => count($this->pending_timers),
+                    'pending_as_batches' => array_sum(array_map('count', $this->pending_as_batch)),
                     'running_jobs'    => $this->running_jobs,
+                    'running_as_jobs' => $this->running_process_count('action_scheduler'),
                     'memory'          => sprintf('%.1f MB', $mem_mb),
                     'running_details' => $running_details,
                 ]);


### PR DESCRIPTION
## Summary

- scan sovereign tenant cron arrays in a fresh subprocess bootstrapped by tenant domain
- preserve tenant registry site IDs in cron payloads instead of collapsing sovereign tenants to blog ID 1
- avoid `switch_to_blog()` for sovereign tenant execution so jobs use tenant-local `wp_` tables
- define cron context and ensure the job log table exists in execution subprocesses

## Why

Sovereign tenants use their own database and tenant-local `wp_` table prefix. The root worker's multisite scan path currently uses `switch_to_blog( $site_id )`, which makes WordPress look for host-style `wp_<site_id>_*` tables inside the tenant DB. That prevents tenant cron jobs from being scanned/executed correctly.

## Verification

- `php -l bin/scan-cron.php`
- `php -l bin/execute-job.php`
- `php -l bin/worker.php`
- `php -l src/class-worker-process.php`
- `php -l src/class-job-payload.php`
- Local runtime check: tenant cron scan returned payloads with the registry site ID and stale-job cleanup ran without the `wp_<site_id>_options` table error.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.36 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI cron-scanning tool and worker rescan support for sovereign-tenant sites.
  * Added a dedicated Action Scheduler processing lane with batching support.

* **Improvements**
  * Worker now skips/rescans sovereign tenants and schedules their jobs in isolation.
  * Job tracking includes tenant-specific identifiers for improved correlation.
  * Added Action Scheduler concurrency and batch size configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->