### PR TITLE
fix: scan per-site Action Scheduler tables

### DIFF
--- a/bin/scan-cron.php
+++ b/bin/scan-cron.php
@@ -114,7 +114,39 @@ if (is_array($crons)) {
     }
 }
 
+if (function_exists('as_get_scheduled_actions') && qw_scan_action_scheduler_tables_exist()) {
+    try {
+        $actions = as_get_scheduled_actions([
+            'status'   => \ActionScheduler_Store::STATUS_PENDING,
+            'per_page' => 500,
+        ]);
+        foreach ($actions as $action_id => $action) {
+            $action_payload = Job_Payload::from_as_action($action_id);
+            if ($action_payload) {
+                $payloads[] = json_decode($action_payload->to_json(), true);
+            }
+        }
+    } catch (\Throwable $e) {
+        fwrite(STDERR, "Action Scheduler scan failed: " . $e->getMessage() . "\n");
+    }
+}
+
 echo json_encode($payloads);
+
+function qw_scan_action_scheduler_tables_exist(): bool
+{
+    global $wpdb;
+
+    foreach (['actions', 'groups'] as $suffix) {
+        $table = $wpdb->prefix . 'actionscheduler_' . $suffix;
+        $found = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->esc_like($table)));
+        if ($found !== $table) {
+            return false;
+        }
+    }
+
+    return true;
+}
 
 function qw_scan_payload_matches_sovereign_registry(int $site_id, string $domain): bool
 {

--- a/src/class-cli-commands.php
+++ b/src/class-cli-commands.php
@@ -71,6 +71,23 @@ class CLI_Commands
         foreach ($sites as $site_id) {
             switch_to_blog($site_id);
 
+            // Scan Action Scheduler pending actions only when this switched
+            // site has its own scheduler tables. Some multisite blogs have no
+            // per-site Action Scheduler tables, and probing them directly
+            // emits database errors.
+            if (function_exists('as_get_scheduled_actions') && $this->action_scheduler_tables_exist()) {
+                $actions = as_get_scheduled_actions([
+                    'status'   => \ActionScheduler_Store::STATUS_PENDING,
+                    'per_page' => 500,
+                ]);
+                foreach ($actions as $action_id => $action) {
+                    $payload = Job_Payload::from_as_action($action_id);
+                    if ($payload && Socket_Client::notify($payload)) {
+                        $count++;
+                    }
+                }
+            }
+
             $crons = _get_cron_array();
             if (is_array($crons)) {
                 foreach ($crons as $timestamp => $hooks) {
@@ -89,24 +106,25 @@ class CLI_Commands
                 }
             }
 
-            // Scan Action Scheduler pending actions
-            if (function_exists('as_get_scheduled_actions')) {
-                $actions = as_get_scheduled_actions([
-                    'status'   => \ActionScheduler_Store::STATUS_PENDING,
-                    'per_page' => 500,
-                ]);
-                foreach ($actions as $action_id => $action) {
-                    $payload = Job_Payload::from_as_action($action_id);
-                    if ($payload && Socket_Client::notify($payload)) {
-                        $count++;
-                    }
-                }
-            }
-
             restore_current_blog();
         }
 
         WP_CLI::success("Sent $count jobs to the queue worker.");
+    }
+
+    private function action_scheduler_tables_exist(): bool
+    {
+        global $wpdb;
+
+        foreach (['actions', 'groups'] as $suffix) {
+            $table = $wpdb->prefix . 'actionscheduler_' . $suffix;
+            $found = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->esc_like($table)));
+            if ($found !== $table) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/class-worker-process.php
+++ b/src/class-worker-process.php
@@ -447,13 +447,6 @@ class Worker_Process
 
         $current_blog_id = get_current_blog_id();
 
-        // Action Scheduler stores its tables at the network/base prefix in
-        // this multisite. Scanning it while switched to sovereign subsites
-        // makes Action Scheduler look for missing per-site AS tables and also
-        // schedules duplicate timers with different site IDs. Scan AS once in
-        // the current/root context, then scan WP-Cron per site below.
-        $this->rescan_action_scheduler_jobs();
-
         foreach ($sites as $site_id) {
             $site_id = (int) $site_id;
             if (isset($sovereign_sites[$site_id])) {
@@ -465,6 +458,12 @@ class Worker_Process
             // Flush stale object cache so we read fresh data from DB.
             wp_cache_delete('cron', 'options');
             wp_cache_delete('alloptions', 'options');
+
+            // Action Scheduler can store actions in either the root tables or
+            // per-site tables. Only scan the currently switched site when its
+            // Action Scheduler tables exist so missing legacy tables do not
+            // produce noisy database errors or duplicate root-site timers.
+            $this->rescan_action_scheduler_jobs();
 
             // Scan WP Cron
             $crons = _get_cron_array();
@@ -630,16 +629,45 @@ class Worker_Process
             return;
         }
 
-        $actions = as_get_scheduled_actions([
-            'status'   => \ActionScheduler_Store::STATUS_PENDING,
-            'per_page' => 500,
-        ]);
+        if (!$this->action_scheduler_tables_exist()) {
+            return;
+        }
+
+        try {
+            $actions = as_get_scheduled_actions([
+                'status'   => \ActionScheduler_Store::STATUS_PENDING,
+                'per_page' => 500,
+            ]);
+        } catch (\Throwable $e) {
+            Worker::log(sprintf(
+                '[RESCAN][ACTION_SCHEDULER][FAIL] Site %d scan failed: %s',
+                get_current_blog_id(),
+                $e->getMessage()
+            ));
+            return;
+        }
+
         foreach ($actions as $action_id => $action) {
             $payload = Job_Payload::from_as_action($action_id);
             if ($payload) {
                 $this->schedule_timer($payload);
             }
         }
+    }
+
+    private function action_scheduler_tables_exist(): bool
+    {
+        global $wpdb;
+
+        foreach (['actions', 'groups'] as $suffix) {
+            $table = $wpdb->prefix . 'actionscheduler_' . $suffix;
+            $found = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->esc_like($table)));
+            if ($found !== $table) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Scan Action Scheduler inside each multisite blog context when scheduler tables exist.
- Guard scans to skip sites without Action Scheduler tables instead of emitting database errors.
- Include Action Scheduler payloads in sovereign tenant scan results.

## Verification

- `php -l src/class-worker-process.php`
- `php -l src/class-cli-commands.php`
- `php -l bin/scan-cron.php`
- `composer validate --no-check-publish`
- `vendor/bin/phpstan analyse --configuration=/tmp/opencode/phpstan-the-perfect-wp-cron.neon --no-progress` *(fails on pre-existing project static-analysis setup / missing third-party symbols; syntax checks above pass)*

For superdav42/tgc.church#111.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.53 plugin for [OpenCode](https://opencode.ai) v1.17.3 with gpt-5.5 spent 1h 20m and 486,612 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced multisite support: system now validates scheduler table availability per site before scanning for pending actions.
  * Improved error resilience in background job scanning to gracefully handle failures without interrupting the scan process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->