### PR TITLE
fix: add Action Scheduler lanes and cron dedupe

### DIFF
--- a/bin/scan-cron.php
+++ b/bin/scan-cron.php
@@ -95,6 +95,7 @@ $bypass_hooks = [
 $payloads = [];
 $crons = _get_cron_array();
 if (is_array($crons)) {
+    $seen_cron_signatures = [];
     foreach ($crons as $timestamp => $hooks) {
         if (!is_array($hooks)) {
             continue;
@@ -104,6 +105,12 @@ if (is_array($crons)) {
                 continue;
             }
             foreach ($events as $event) {
+                $signature = qw_scan_cron_event_signature($hook, $event, (int) $timestamp);
+                if (isset($seen_cron_signatures[$signature])) {
+                    continue;
+                }
+                $seen_cron_signatures[$signature] = true;
+
                 $event_obj = (object) array_merge($event, [
                     'hook'      => $hook,
                     'timestamp' => $timestamp,
@@ -146,6 +153,19 @@ function qw_scan_action_scheduler_tables_exist(): bool
     }
 
     return true;
+}
+
+function qw_scan_cron_event_signature(string $hook, array $event, int $timestamp): string
+{
+    $event_timestamp = empty($event['schedule']) ? $timestamp : 0;
+
+    return sprintf(
+        '%s:%s:%d:%s',
+        $hook,
+        $event['schedule'] ?? '',
+        $event_timestamp,
+        md5(serialize($event['args'] ?? []))
+    );
 }
 
 function qw_scan_payload_matches_sovereign_registry(int $site_id, string $domain): bool

--- a/src/class-cli-commands.php
+++ b/src/class-cli-commands.php
@@ -6,6 +6,14 @@ use WP_CLI;
 
 class CLI_Commands
 {
+    private const BYPASS_CRON_HOOKS = [
+        'wp_version_check',
+        'wp_update_plugins',
+        'wp_update_themes',
+        'action_scheduler_run_queue',
+        'action_scheduler_run_cleanup',
+    ];
+
     /**
      * Show queue worker status.
      *
@@ -32,14 +40,31 @@ class CLI_Commands
         WP_CLI::log(sprintf('  PID:            %d', $data['pid'] ?? 0));
         WP_CLI::log(sprintf('  Uptime:         %s', $data['uptime'] ?? 'unknown'));
         WP_CLI::log(sprintf('  Pending timers: %d', $data['pending_timers'] ?? 0));
+        WP_CLI::log(sprintf('  Pending AS:     %d', $data['pending_as_batches'] ?? 0));
         WP_CLI::log(sprintf('  Running jobs:   %d', $data['running_jobs'] ?? 0));
+        WP_CLI::log(sprintf('  Running AS:     %d', $data['running_as_jobs'] ?? 0));
         WP_CLI::log(sprintf('  Memory:         %s', $data['memory'] ?? 'unknown'));
+
+        if (!empty($data['pending_as_lanes'])) {
+            WP_CLI::log('  Pending AS lanes:');
+            foreach ($data['pending_as_lanes'] as $lane => $count) {
+                WP_CLI::log(sprintf('    - %s: %d', $lane, $count));
+            }
+        }
+
+        if (!empty($data['running_as_lanes'])) {
+            WP_CLI::log('  Running AS lanes:');
+            foreach ($data['running_as_lanes'] as $lane => $count) {
+                WP_CLI::log(sprintf('    - %s: %d', $lane, $count));
+            }
+        }
 
         if (!empty($data['running_details'])) {
             WP_CLI::log('  Currently executing:');
             foreach ($data['running_details'] as $detail) {
                 WP_CLI::log(sprintf(
-                    '    - site %d: %s (%d jobs, %ds elapsed)',
+                    '    - %s site %d: %s (%d jobs, %ds elapsed)',
+                    $detail['lane'] ?? 'wp_cron',
                     $detail['site_id'],
                     $detail['hook'],
                     $detail['count'],
@@ -90,9 +115,20 @@ class CLI_Commands
 
             $crons = _get_cron_array();
             if (is_array($crons)) {
+                $seen_cron_signatures = [];
                 foreach ($crons as $timestamp => $hooks) {
                     foreach ($hooks as $hook => $events) {
+                        if (in_array($hook, self::BYPASS_CRON_HOOKS, true)) {
+                            continue;
+                        }
+
                         foreach ($events as $key => $event) {
+                            $signature = $this->cron_event_signature($hook, $event, (int) $timestamp);
+                            if (isset($seen_cron_signatures[$signature])) {
+                                continue;
+                            }
+                            $seen_cron_signatures[$signature] = true;
+
                             $event_obj = (object) array_merge($event, [
                                 'hook'      => $hook,
                                 'timestamp' => $timestamp,
@@ -152,5 +188,18 @@ class CLI_Commands
         fclose($socket);
 
         WP_CLI::success('Sent restart signal to queue worker. systemd will restart it.');
+    }
+
+    private function cron_event_signature(string $hook, array $event, int $timestamp): string
+    {
+        $event_timestamp = empty($event['schedule']) ? $timestamp : 0;
+
+        return sprintf(
+            '%s:%s:%d:%s',
+            $hook,
+            $event['schedule'] ?? '',
+            $event_timestamp,
+            md5(serialize($event['args'] ?? []))
+        );
     }
 }

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -29,6 +29,39 @@ class Config
         return (int) self::get('QUEUE_WORKER_AS_MAX_BATCH_SIZE', 10);
     }
 
+    public static function action_scheduler_lanes(): array
+    {
+        $value = self::get('QUEUE_WORKER_AS_LANES', []);
+        if (is_string($value)) {
+            if (trim($value) === '') {
+                return [];
+            }
+            $value = json_decode($value, true);
+        }
+
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($value as $lane) {
+            if (!is_array($lane) || empty($lane['name'])) {
+                continue;
+            }
+
+            $normalized[] = [
+                'name'           => self::sanitize_lane_name((string) $lane['name']),
+                'sites'          => self::normalize_int_list($lane['sites'] ?? $lane['site_ids'] ?? []),
+                'groups'         => self::normalize_string_list($lane['groups'] ?? []),
+                'hooks'          => self::normalize_string_list($lane['hooks'] ?? []),
+                'max_concurrent' => max(1, (int) ($lane['max_concurrent'] ?? self::action_scheduler_max_concurrent())),
+                'max_batch_size' => max(1, (int) ($lane['max_batch_size'] ?? self::action_scheduler_max_batch_size())),
+            ];
+        }
+
+        return $normalized;
+    }
+
     public static function max_batch_size(): int
     {
         return (int) self::get('QUEUE_WORKER_MAX_BATCH_SIZE', 50);
@@ -47,6 +80,11 @@ class Config
     public static function rescan_interval(): int
     {
         return (int) self::get('QUEUE_WORKER_RESCAN_INTERVAL', 60);
+    }
+
+    public static function action_scheduler_rescan_interval(): int
+    {
+        return max(1, (int) self::get('QUEUE_WORKER_AS_RESCAN_INTERVAL', 5));
     }
 
     public static function memory_limit(): int
@@ -92,5 +130,43 @@ class Config
             return $env;
         }
         return $default;
+    }
+
+    private static function sanitize_lane_name(string $name): string
+    {
+        $name = preg_replace('/[^a-zA-Z0-9_.:-]+/', '-', trim($name));
+        if ($name === '' || $name === 'wp_cron') {
+            return 'action_scheduler';
+        }
+
+        return $name;
+    }
+
+    private static function normalize_int_list(mixed $value): array
+    {
+        $items = is_array($value) ? $value : [$value];
+        $result = [];
+        foreach ($items as $item) {
+            if ($item === '' || $item === null) {
+                continue;
+            }
+            $result[] = (int) $item;
+        }
+
+        return array_values(array_unique(array_filter($result)));
+    }
+
+    private static function normalize_string_list(mixed $value): array
+    {
+        $items = is_array($value) ? $value : [$value];
+        $result = [];
+        foreach ($items as $item) {
+            $item = trim((string) $item);
+            if ($item !== '') {
+                $result[] = $item;
+            }
+        }
+
+        return array_values(array_unique($result));
     }
 }

--- a/src/class-job-payload.php
+++ b/src/class-job-payload.php
@@ -13,6 +13,7 @@ class Job_Payload
     public int $interval;
     public string $source; // 'wp_cron' | 'action_scheduler'
     public int $action_id;
+    public string $group;
 
     public function __construct(array $data = [])
     {
@@ -25,6 +26,7 @@ class Job_Payload
         $this->interval  = $data['interval'] ?? 0;
         $this->source    = $data['source'] ?? 'wp_cron';
         $this->action_id = $data['action_id'] ?? 0;
+        $this->group     = $data['group'] ?? '';
     }
 
     public function to_json(): string
@@ -39,6 +41,7 @@ class Job_Payload
             'interval'  => $this->interval,
             'source'    => $this->source,
             'action_id' => $this->action_id,
+            'group'     => $this->group,
         ]);
     }
 
@@ -68,6 +71,7 @@ class Job_Payload
             'schedule'  => $event->schedule ?? '',
             'interval'  => $interval,
             'source'    => 'wp_cron',
+            'group'     => '',
         ]);
     }
 
@@ -95,17 +99,19 @@ class Job_Payload
             'timestamp' => $timestamp,
             'source'    => 'action_scheduler',
             'action_id' => $action_id,
+            'group'     => method_exists($action, 'get_group') ? $action->get_group() : '',
         ]);
     }
 
     public function tracking_key(): string
     {
         return sprintf(
-            '%s:%d:%s:%s:%s:%d',
+            '%s:%d:%s:%s:%s:%s:%d',
             $this->source,
             $this->site_id,
             md5($this->site_url),
             $this->hook,
+            $this->group,
             md5(serialize($this->args)),
             $this->timestamp
         );

--- a/src/class-worker-process.php
+++ b/src/class-worker-process.php
@@ -30,6 +30,8 @@ class Worker_Process
     private int $max_batch_size;
     private int $as_max_concurrent;
     private int $as_max_batch_size;
+    private array $as_lanes;
+    private int $as_rescan_interval;
     private int $batch_timeout;
     private int $rescan_interval;
     private int $memory_limit;
@@ -45,7 +47,7 @@ class Worker_Process
     /** @var array<int, list<Job_Payload>> site_id => [payload, ...] */
     private array $pending_batch = [];
 
-    /** @var array<int, list<Job_Payload>> site_id => [payload, ...] */
+    /** @var array<string, array<int, list<Job_Payload>>> lane => site_id => [payload, ...] */
     private array $pending_as_batch = [];
 
     private int $running_jobs = 0;
@@ -62,6 +64,8 @@ class Worker_Process
         $this->max_batch_size  = Config::max_batch_size();
         $this->as_max_concurrent = Config::action_scheduler_max_concurrent();
         $this->as_max_batch_size = Config::action_scheduler_max_batch_size();
+        $this->as_lanes       = Config::action_scheduler_lanes();
+        $this->as_rescan_interval = Config::action_scheduler_rescan_interval();
         $this->batch_timeout   = Config::batch_timeout();
         $this->rescan_interval = Config::rescan_interval();
         $this->memory_limit    = Config::memory_limit();
@@ -108,6 +112,16 @@ class Worker_Process
             Worker::log(sprintf('[W%d][RESCAN] %d timers pending, rescanning...', $worker_id, count($this->pending_timers)));
             $this->rescan_all_jobs();
         });
+
+        // Action Scheduler can miss instant socket notification when an action
+        // is enqueued before its integration hook is registered in a request.
+        // Keep a short AS-only safety scan in the current/root context; the
+        // full multisite rescan still covers per-site and sovereign tables.
+        Timer::add($this->as_rescan_interval, function () use ($worker_id) {
+            Worker::log(sprintf('[W%d][AS_RESCAN] scanning pending Action Scheduler jobs...', $worker_id));
+            $this->rescan_action_scheduler_jobs();
+        });
+
         $stagger = $worker_id * 5;
         if ($stagger > 0) {
             Timer::add($stagger, function () {}, null, false);
@@ -215,7 +229,8 @@ class Worker_Process
     {
         $key = $payload->tracking_key();
 
-        if ($this->running_process_count('action_scheduler') >= $this->as_max_concurrent) {
+        $lane = $this->action_scheduler_lane_for($payload);
+        if ($this->running_process_count($lane) >= $this->lane_max_concurrent($lane)) {
             $timer_id = Timer::add(1, fn($p) => $this->execute_action_scheduler_job($p), [$payload], false);
             $this->pending_timers[$key] = $timer_id;
             return;
@@ -226,7 +241,7 @@ class Worker_Process
             return;
         }
 
-        $this->pending_as_batch[$payload->site_id][] = $payload;
+        $this->pending_as_batch[$lane][$payload->site_id][] = $payload;
     }
 
     /**
@@ -316,20 +331,76 @@ class Worker_Process
      */
     private function flush_action_scheduler_batches(): void
     {
-        foreach ($this->pending_as_batch as $site_id => $payloads) {
-            if (empty($payloads)) {
-                unset($this->pending_as_batch[$site_id]);
-                continue;
+        foreach ($this->pending_as_batch as $lane => $site_batches) {
+            foreach ($site_batches as $site_id => $payloads) {
+                if (empty($payloads)) {
+                    unset($this->pending_as_batch[$lane][$site_id]);
+                    continue;
+                }
+                if ($this->running_process_count($lane) >= $this->lane_max_concurrent($lane)) {
+                    break;
+                }
+                $batch = array_splice($this->pending_as_batch[$lane][$site_id], 0, $this->lane_max_batch_size($lane));
+                $this->spawn_batch($batch, 0, $lane);
+                if (empty($this->pending_as_batch[$lane][$site_id])) {
+                    unset($this->pending_as_batch[$lane][$site_id]);
+                }
             }
-            if ($this->running_process_count('action_scheduler') >= $this->as_max_concurrent) {
-                break;
-            }
-            $batch = array_splice($this->pending_as_batch[$site_id], 0, $this->as_max_batch_size);
-            $this->spawn_batch($batch, 0, 'action_scheduler');
-            if (empty($this->pending_as_batch[$site_id])) {
-                unset($this->pending_as_batch[$site_id]);
+
+            if (empty($this->pending_as_batch[$lane])) {
+                unset($this->pending_as_batch[$lane]);
             }
         }
+    }
+
+    private function action_scheduler_lane_for(Job_Payload $payload): string
+    {
+        foreach ($this->as_lanes as $lane) {
+            if (!$this->lane_matches($lane, $payload)) {
+                continue;
+            }
+
+            return $lane['name'];
+        }
+
+        return 'action_scheduler';
+    }
+
+    private function lane_matches(array $lane, Job_Payload $payload): bool
+    {
+        if (!empty($lane['sites']) && !in_array($payload->site_id, $lane['sites'], true)) {
+            return false;
+        }
+        if (!empty($lane['groups']) && !in_array($payload->group, $lane['groups'], true)) {
+            return false;
+        }
+        if (!empty($lane['hooks']) && !in_array($payload->hook, $lane['hooks'], true)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function lane_max_concurrent(string $lane_name): int
+    {
+        foreach ($this->as_lanes as $lane) {
+            if ($lane['name'] === $lane_name) {
+                return (int) $lane['max_concurrent'];
+            }
+        }
+
+        return $this->as_max_concurrent;
+    }
+
+    private function lane_max_batch_size(string $lane_name): int
+    {
+        foreach ($this->as_lanes as $lane) {
+            if ($lane['name'] === $lane_name) {
+                return (int) $lane['max_batch_size'];
+            }
+        }
+
+        return $this->as_max_batch_size;
     }
 
     private function running_process_count(string $lane): int
@@ -468,6 +539,7 @@ class Worker_Process
             // Scan WP Cron
             $crons = _get_cron_array();
             if (is_array($crons)) {
+                $seen_cron_signatures = [];
                 foreach ($crons as $timestamp => $hooks) {
                     if (!is_array($hooks)) {
                         continue;
@@ -484,6 +556,12 @@ class Worker_Process
                         }
 
                         foreach ($events as $event) {
+                            $signature = $this->cron_event_signature($hook, $event, (int) $timestamp);
+                            if (isset($seen_cron_signatures[$signature])) {
+                                continue;
+                            }
+                            $seen_cron_signatures[$signature] = true;
+
                             $event_obj = (object) array_merge($event, [
                                 'hook'      => $hook,
                                 'timestamp' => $timestamp,
@@ -727,9 +805,11 @@ class Worker_Process
                     'uptime'          => sprintf('%dh %dm %ds', $hours, $mins, $secs),
                     'uptime_seconds'  => $uptime,
                     'pending_timers'  => count($this->pending_timers),
-                    'pending_as_batches' => array_sum(array_map('count', $this->pending_as_batch)),
+                    'pending_as_batches' => $this->pending_action_scheduler_count(),
                     'running_jobs'    => $this->running_jobs,
-                    'running_as_jobs' => $this->running_process_count('action_scheduler'),
+                    'running_as_jobs' => $this->running_action_scheduler_count(),
+                    'running_as_lanes' => $this->running_action_scheduler_counts(),
+                    'pending_as_lanes' => $this->pending_action_scheduler_counts(),
                     'memory'          => sprintf('%.1f MB', $mem_mb),
                     'running_details' => $running_details,
                 ]);
@@ -746,6 +826,53 @@ class Worker_Process
                 $connection->close();
                 break;
         }
+    }
+
+    private function pending_action_scheduler_count(): int
+    {
+        return array_sum($this->pending_action_scheduler_counts());
+    }
+
+    private function pending_action_scheduler_counts(): array
+    {
+        $counts = [];
+        foreach ($this->pending_as_batch as $lane => $site_batches) {
+            $counts[$lane] = array_sum(array_map('count', $site_batches));
+        }
+
+        return $counts;
+    }
+
+    private function running_action_scheduler_counts(): array
+    {
+        $counts = [];
+        foreach ($this->running_processes as $proc) {
+            $lane = $proc['lane'] ?? 'wp_cron';
+            if ($lane === 'wp_cron') {
+                continue;
+            }
+            $counts[$lane] = ($counts[$lane] ?? 0) + 1;
+        }
+
+        return $counts;
+    }
+
+    private function running_action_scheduler_count(): int
+    {
+        return array_sum($this->running_action_scheduler_counts());
+    }
+
+    private function cron_event_signature(string $hook, array $event, int $timestamp): string
+    {
+        $event_timestamp = empty($event['schedule']) ? $timestamp : 0;
+
+        return sprintf(
+            '%s:%s:%d:%s',
+            $hook,
+            $event['schedule'] ?? '',
+            $event_timestamp,
+            md5(serialize($event['args'] ?? []))
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add configurable Action Scheduler lanes via `QUEUE_WORKER_AS_LANES`, with group-aware payload tracking and per-lane status output.
- Keep Action Scheduler work on dedicated concurrency lanes while preserving the current per-site and sovereign tenant scan paths from `origin/main`.
- De-duplicate recurring WP-Cron signatures in worker, WP-CLI populate, and sovereign scan flows while preserving one-off events by timestamp.

## Review notes
- The local unstaged work was not already on `origin`; `origin/main` already contained related per-site/sovereign scan fixes, so this branch was rebased onto `origin/main` before committing to avoid regressing those changes.

## Verification
- `php -l src/class-cli-commands.php && php -l src/class-config.php && php -l src/class-job-payload.php && php -l src/class-worker-process.php && php -l bin/scan-cron.php`
- `composer validate --strict`
- `git diff --check`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5
