### PR TITLE
GH#25: fix: keep queue status responsive under rescan backlog

### DIFF
--- a/src/class-cli-commands.php
+++ b/src/class-cli-commands.php
@@ -32,7 +32,8 @@ class CLI_Commands
 
         $data = Socket_Client::send_command('status');
         if (!$data) {
-            WP_CLI::warning('Worker did not respond to status request.');
+            $error = Socket_Client::get_last_error() ?: 'unknown_error';
+            WP_CLI::warning(sprintf('Worker status request failed: %s.', $error));
             return;
         }
 
@@ -44,6 +45,14 @@ class CLI_Commands
         WP_CLI::log(sprintf('  Running jobs:   %d', $data['running_jobs'] ?? 0));
         WP_CLI::log(sprintf('  Running AS:     %d', $data['running_as_jobs'] ?? 0));
         WP_CLI::log(sprintf('  Memory:         %s', $data['memory'] ?? 'unknown'));
+
+        if (!empty($data['rescan']) && is_array($data['rescan'])) {
+            WP_CLI::log(sprintf(
+                '  Rescan:         %s (last duration: %ds)',
+                !empty($data['rescan']['in_progress']) ? 'in progress' : 'idle',
+                (int) ($data['rescan']['last_duration'] ?? 0)
+            ));
+        }
 
         if (!empty($data['pending_as_lanes'])) {
             WP_CLI::log('  Pending AS lanes:');

--- a/src/class-socket-client.php
+++ b/src/class-socket-client.php
@@ -4,9 +4,16 @@ namespace QueueWorker;
 
 class Socket_Client
 {
+    private static string $last_error = '';
+
     public static function get_socket_path(): string
     {
         return Config::socket_path();
+    }
+
+    public static function get_last_error(): string
+    {
+        return self::$last_error;
     }
 
     public static function notify(Job_Payload $payload): bool
@@ -23,23 +30,32 @@ class Socket_Client
 
     public static function send_command(string $command, int $timeout = 5): ?array
     {
+        self::$last_error = '';
         $path = self::get_socket_path();
         $socket = @stream_socket_client('unix://' . $path, $errno, $errstr, 2);
         if (!$socket) {
+            self::$last_error = sprintf('connect_failed: %s (%d)', $errstr ?: 'unknown error', $errno);
             return null;
         }
 
         fwrite($socket, json_encode(['command' => $command]) . "\n");
         stream_set_timeout($socket, $timeout);
         $response = fgets($socket);
+        $meta = stream_get_meta_data($socket);
         fclose($socket);
 
         if (!$response) {
+            self::$last_error = !empty($meta['timed_out']) ? 'timeout_waiting_for_response' : 'empty_response';
             return null;
         }
 
         $data = json_decode($response, true);
-        return is_array($data) ? $data : null;
+        if (!is_array($data)) {
+            self::$last_error = 'malformed_response';
+            return null;
+        }
+
+        return $data;
     }
 
     public static function is_worker_running(): bool

--- a/src/class-worker-process.php
+++ b/src/class-worker-process.php
@@ -52,6 +52,10 @@ class Worker_Process
 
     private int $running_jobs = 0;
     private int $start_time;
+    private bool $is_rescanning = false;
+    private int $last_rescan_started = 0;
+    private int $last_rescan_finished = 0;
+    private int $last_rescan_duration = 0;
 
     public function __construct(string $wp_load, string $primary_domain, string $execute_script, string $scan_script = '')
     {
@@ -102,15 +106,26 @@ class Worker_Process
         // Subprocess polling timer — every 0.5 seconds
         Timer::add(0.5, fn() => $this->poll_processes($worker_id));
 
-        // Initial DB scan
-        Worker::log(sprintf('[W%d] Scanning database for pending jobs...', $worker_id));
-        $this->rescan_all_jobs();
-        Worker::log(sprintf('[W%d] Loaded %d pending jobs.', $worker_id, count($this->pending_timers)));
+        // Initial DB scan. Only one coordinator worker performs the expensive
+        // full-network scan so large multisite networks do not block every
+        // event loop child at startup.
+        if ($this->is_rescan_coordinator($worker_id)) {
+            Worker::log(sprintf('[W%d] Scanning database for pending jobs...', $worker_id));
+            $this->run_full_rescan($worker_id);
+            Worker::log(sprintf('[W%d] Loaded %d pending jobs.', $worker_id, count($this->pending_timers)));
+        } else {
+            Worker::log(sprintf('[W%d] Skipping full-network scan; worker 0 is rescan coordinator.', $worker_id));
+        }
 
-        // Periodic rescan timer (staggered by worker ID)
+        // Periodic full-network rescan. Keep it on the coordinator worker only
+        // so status commands and urgent Action Scheduler notifications can be
+        // handled by other children while WP-Cron backlogs are being scanned.
         Timer::add($this->rescan_interval, function () use ($worker_id) {
+            if (!$this->is_rescan_coordinator($worker_id)) {
+                return;
+            }
             Worker::log(sprintf('[W%d][RESCAN] %d timers pending, rescanning...', $worker_id, count($this->pending_timers)));
-            $this->rescan_all_jobs();
+            $this->run_full_rescan($worker_id);
         });
 
         // Action Scheduler can miss instant socket notification when an action
@@ -584,6 +599,30 @@ class Worker_Process
         }
     }
 
+    private function is_rescan_coordinator(int $worker_id): bool
+    {
+        return $worker_id === 0;
+    }
+
+    private function run_full_rescan(int $worker_id): void
+    {
+        if ($this->is_rescanning) {
+            Worker::log(sprintf('[W%d][RESCAN] Previous full-network rescan still running; skipping overlap.', $worker_id));
+            return;
+        }
+
+        $this->is_rescanning = true;
+        $this->last_rescan_started = time();
+
+        try {
+            $this->rescan_all_jobs();
+        } finally {
+            $this->last_rescan_finished = time();
+            $this->last_rescan_duration = max(0, $this->last_rescan_finished - $this->last_rescan_started);
+            $this->is_rescanning = false;
+        }
+    }
+
     /**
      * Load sovereign tenant entries from the generated multi-tenancy registry.
      *
@@ -812,8 +851,14 @@ class Worker_Process
                     'pending_as_lanes' => $this->pending_action_scheduler_counts(),
                     'memory'          => sprintf('%.1f MB', $mem_mb),
                     'running_details' => $running_details,
+                    'rescan'          => [
+                        'in_progress' => $this->is_rescanning,
+                        'last_started' => $this->last_rescan_started,
+                        'last_finished' => $this->last_rescan_finished,
+                        'last_duration' => $this->last_rescan_duration,
+                    ],
                 ]);
-                $connection->send($response);
+                $connection->close($response . "\n");
                 break;
 
             case 'restart':


### PR DESCRIPTION
## Summary

Line-delimited and close status command responses; add socket-client failure reasons for CLI status diagnostics; limit full-network rescans to worker 0 with rescan state in status so other worker children remain available for status requests and urgent Action Scheduler notifications.

## Files Changed

src/class-cli-commands.php,src/class-socket-client.php,src/class-worker-process.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l src/class-socket-client.php src/class-worker-process.php src/class-cli-commands.php

Resolves #25


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 2m and 51,526 tokens on this as a headless worker.