### PR TITLE
GH#21: fix: improve action scheduler socket notifications

### DIFF
--- a/src/class-action-scheduler-bridge.php
+++ b/src/class-action-scheduler-bridge.php
@@ -4,6 +4,8 @@ namespace QueueWorker;
 
 class Action_Scheduler_Bridge
 {
+    private static bool $stored_action_hook_registered = false;
+
     public static function register(): void
     {
         // Remove the default AS queue runner — the worker handles execution
@@ -14,7 +16,17 @@ class Action_Scheduler_Bridge
             );
         }
 
+        self::register_stored_action_hook();
+    }
+
+    public static function register_stored_action_hook(): void
+    {
+        if (self::$stored_action_hook_registered) {
+            return;
+        }
+
         add_action('action_scheduler_stored_action', [__CLASS__, 'on_stored_action']);
+        self::$stored_action_hook_registered = true;
     }
 
     public static function on_stored_action(int $action_id): void

--- a/src/class-socket-client.php
+++ b/src/class-socket-client.php
@@ -21,11 +21,42 @@ class Socket_Client
         $path = self::get_socket_path();
         $socket = @stream_socket_client('unix://' . $path, $errno, $errstr, 1);
         if (!$socket) {
+            self::log_notify_failure($payload, sprintf(
+                'connect failed for %s: [%d] %s',
+                $path,
+                (int) $errno,
+                $errstr !== '' ? $errstr : 'unknown error'
+            ));
             return false;
         }
-        fwrite($socket, $payload->to_json() . "\n");
+
+        $message = $payload->to_json() . "\n";
+        $written = fwrite($socket, $message);
         fclose($socket);
+
+        if ($written !== strlen($message)) {
+            self::log_notify_failure($payload, sprintf(
+                'write failed for %s: wrote %d of %d bytes',
+                $path,
+                $written === false ? 0 : $written,
+                strlen($message)
+            ));
+            return false;
+        }
+
         return true;
+    }
+
+    private static function log_notify_failure(Job_Payload $payload, string $reason): void
+    {
+        error_log(sprintf(
+            '[The Perfect WP Cron][Socket Notify Failed] source=%s site_id=%d hook=%s action_id=%d reason=%s',
+            $payload->source,
+            $payload->site_id,
+            $payload->hook,
+            $payload->action_id,
+            $reason
+        ));
     }
 
     public static function send_command(string $command, int $timeout = 5): ?array

--- a/the-perfect-wp-cron.php
+++ b/the-perfect-wp-cron.php
@@ -31,6 +31,7 @@ if (defined('QUEUE_WORKER_RUNNING') && QUEUE_WORKER_RUNNING) {
 }
 
 add_action('init', ['QueueWorker\\Cron_Interceptor', 'register']);
+QueueWorker\Action_Scheduler_Bridge::register_stored_action_hook();
 add_action('action_scheduler_init', ['QueueWorker\\Action_Scheduler_Bridge', 'register']);
 
 // Admin menu


### PR DESCRIPTION
## Summary

Registered the Action Scheduler stored-action hook as soon as the plugin loads so frontend checkout-created actions cannot outrun the bridge's action_scheduler_init registration. Kept action_scheduler_init for queue-runner removal and made the stored-action registration idempotent. Added observable Socket_Client notify failure logging for connect and short-write failures without logging action args.

## Files Changed

src/class-action-scheduler-bridge.php,src/class-socket-client.php,the-perfect-wp-cron.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l across all tracked PHP files; composer validate --no-check-publish

Resolves #21


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 2m and 61,676 tokens on this as a headless worker.