### PR TITLE
GH#20: feat: log queue wait latency

### DIFF
--- a/src/class-job-executor.php
+++ b/src/class-job-executor.php
@@ -40,6 +40,7 @@ class Job_Executor
             $source    = $job['source'] ?? 'wp_cron';
             $hook      = $job['hook'];
             $job_start = microtime(true);
+            $scheduled = (int) ($job['timestamp'] ?? 0);
             $status    = 'ok';
             $error     = null;
 
@@ -64,14 +65,23 @@ class Job_Executor
 
             $this->cancel_alarm();
 
-            $duration_ms = (int) round((microtime(true) - $job_start) * 1000);
+            $job_completed = microtime(true);
+            $duration_ms   = (int) round(($job_completed - $job_start) * 1000);
+            $wait_ms       = $scheduled > 0 ? max(0, (int) round(($job_start - $scheduled) * 1000)) : null;
             Job_Log::insert(
                 (int) ($job['site_id'] ?? $this->site_id),
                 $hook,
                 $source,
                 $status,
                 $duration_ms,
-                $error
+                $error,
+                $scheduled > 0 ? gmdate('Y-m-d H:i:s', $scheduled) : null,
+                gmdate('Y-m-d H:i:s', (int) $job_start),
+                gmdate('Y-m-d H:i:s', (int) $job_completed),
+                $wait_ms,
+                $duration_ms,
+                (string) ($job['lane'] ?? ($source === 'action_scheduler' ? 'action_scheduler' : 'wp_cron')),
+                !empty($job['action_id']) ? (int) $job['action_id'] : null
             );
         }
 

--- a/src/class-job-list-table.php
+++ b/src/class-job-list-table.php
@@ -23,8 +23,11 @@ class Job_List_Table extends \WP_List_Table
             'site_id'      => 'Site',
             'hook'         => 'Hook',
             'source'       => 'Source',
+            'lane'         => 'Lane',
+            'action_id'    => 'Action ID',
             'status'       => 'Status',
-            'duration_ms'  => 'Duration',
+            'wait_ms'      => 'Wait',
+            'duration_ms'  => 'Execution',
             'error_msg'    => 'Error',
             'completed_at' => 'Completed',
         ];
@@ -34,9 +37,13 @@ class Job_List_Table extends \WP_List_Table
     {
         return [
             'completed_at' => ['completed_at', true], // default DESC
+            'wait_ms'      => ['wait_ms', false],
             'duration_ms'  => ['duration_ms', false],
+            'execution_ms' => ['execution_ms', false],
             'site_id'      => ['site_id', false],
             'hook'         => ['hook', false],
+            'lane'         => ['lane', false],
+            'action_id'    => ['action_id', false],
         ];
     }
 
@@ -197,6 +204,18 @@ class Job_List_Table extends \WP_List_Table
             : '<span class="qw-source qw-source-cron">Cron</span>';
     }
 
+    protected function column_lane($item): string
+    {
+        $lane = $item['lane'] ?? '';
+        return $lane !== '' ? '<code>' . esc_html($lane) . '</code>' : '&mdash;';
+    }
+
+    protected function column_action_id($item): string
+    {
+        $action_id = (int) ($item['action_id'] ?? 0);
+        return $action_id > 0 ? (string) $action_id : '&mdash;';
+    }
+
     protected function column_status($item): string
     {
         $status = $item['status'] ?? 'ok';
@@ -211,7 +230,16 @@ class Job_List_Table extends \WP_List_Table
 
     protected function column_duration_ms($item): string
     {
-        return self::format_duration((int) $item['duration_ms']);
+        return self::format_duration((int) ($item['execution_ms'] ?? $item['duration_ms']));
+    }
+
+    protected function column_wait_ms($item): string
+    {
+        if (!isset($item['wait_ms']) || $item['wait_ms'] === null) {
+            return '&mdash;';
+        }
+
+        return self::format_duration((int) $item['wait_ms']);
     }
 
     protected function column_error_msg($item): string

--- a/src/class-job-log.php
+++ b/src/class-job-log.php
@@ -21,17 +21,56 @@ class Job_Log
             site_id BIGINT UNSIGNED NOT NULL,
             hook VARCHAR(255) NOT NULL,
             source VARCHAR(20) NOT NULL DEFAULT 'wp_cron',
+            lane VARCHAR(100) NULL,
+            action_id BIGINT UNSIGNED NULL,
             status VARCHAR(10) NOT NULL DEFAULT 'ok',
             duration_ms INT UNSIGNED NOT NULL DEFAULT 0,
+            wait_ms INT UNSIGNED NULL,
+            execution_ms INT UNSIGNED NULL,
             error_msg TEXT NULL,
+            scheduled_at DATETIME NULL,
+            started_at DATETIME NULL,
             completed_at DATETIME NOT NULL,
             PRIMARY KEY (id),
             KEY site_hook (site_id, hook),
+            KEY lane (lane),
+            KEY action_id (action_id),
             KEY status (status),
+            KEY scheduled_at (scheduled_at),
             KEY completed_at (completed_at)
         ) ENGINE=InnoDB $charset";
 
         $wpdb->query($sql);
+
+        self::add_column_if_missing($table, 'lane', 'ALTER TABLE `' . $table . '` ADD `lane` VARCHAR(100) NULL AFTER `source`');
+        self::add_column_if_missing($table, 'action_id', 'ALTER TABLE `' . $table . '` ADD `action_id` BIGINT UNSIGNED NULL AFTER `lane`');
+        self::add_column_if_missing($table, 'wait_ms', 'ALTER TABLE `' . $table . '` ADD `wait_ms` INT UNSIGNED NULL AFTER `duration_ms`');
+        self::add_column_if_missing($table, 'execution_ms', 'ALTER TABLE `' . $table . '` ADD `execution_ms` INT UNSIGNED NULL AFTER `wait_ms`');
+        self::add_column_if_missing($table, 'scheduled_at', 'ALTER TABLE `' . $table . '` ADD `scheduled_at` DATETIME NULL AFTER `error_msg`');
+        self::add_column_if_missing($table, 'started_at', 'ALTER TABLE `' . $table . '` ADD `started_at` DATETIME NULL AFTER `scheduled_at`');
+        self::add_index_if_missing($table, 'lane', 'ALTER TABLE `' . $table . '` ADD KEY `lane` (`lane`)');
+        self::add_index_if_missing($table, 'action_id', 'ALTER TABLE `' . $table . '` ADD KEY `action_id` (`action_id`)');
+        self::add_index_if_missing($table, 'scheduled_at', 'ALTER TABLE `' . $table . '` ADD KEY `scheduled_at` (`scheduled_at`)');
+    }
+
+    private static function add_column_if_missing(string $table, string $column, string $alter_sql): void
+    {
+        global $wpdb;
+
+        $exists = $wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM `$table` LIKE %s", $column));
+        if ($exists === null) {
+            $wpdb->query($alter_sql);
+        }
+    }
+
+    private static function add_index_if_missing(string $table, string $index, string $alter_sql): void
+    {
+        global $wpdb;
+
+        $exists = $wpdb->get_var($wpdb->prepare("SHOW INDEX FROM `$table` WHERE Key_name = %s", $index));
+        if ($exists === null) {
+            $wpdb->query($alter_sql);
+        }
     }
 
     public static function insert(
@@ -40,7 +79,14 @@ class Job_Log
         string $source,
         string $status,
         int $duration_ms,
-        ?string $error_msg = null
+        ?string $error_msg = null,
+        ?string $scheduled_at = null,
+        ?string $started_at = null,
+        ?string $completed_at = null,
+        ?int $wait_ms = null,
+        ?int $execution_ms = null,
+        ?string $lane = null,
+        ?int $action_id = null
     ): void {
         global $wpdb;
         $table = self::table();
@@ -49,11 +95,17 @@ class Job_Log
             'site_id'      => $site_id,
             'hook'         => $hook,
             'source'       => $source,
+            'lane'         => $lane,
+            'action_id'    => $action_id,
             'status'       => $status,
             'duration_ms'  => $duration_ms,
+            'wait_ms'      => $wait_ms,
+            'execution_ms' => $execution_ms,
             'error_msg'    => $error_msg,
-            'completed_at' => current_time('mysql', true),
-        ], ['%d', '%s', '%s', '%s', '%d', '%s', '%s']);
+            'scheduled_at' => $scheduled_at,
+            'started_at'   => $started_at,
+            'completed_at' => $completed_at ?: current_time('mysql', true),
+        ], ['%d', '%s', '%s', '%s', '%d', '%s', '%d', '%d', '%d', '%s', '%s', '%s', '%s']);
     }
 
     public static function query(array $args = []): array
@@ -95,7 +147,7 @@ class Job_Log
 
         $where_sql = $where ? 'WHERE ' . implode(' AND ', $where) : '';
 
-        $allowed_orderby = ['completed_at', 'duration_ms', 'site_id', 'hook', 'status'];
+        $allowed_orderby = ['completed_at', 'scheduled_at', 'started_at', 'duration_ms', 'wait_ms', 'execution_ms', 'site_id', 'hook', 'status', 'source', 'lane', 'action_id'];
         $orderby = in_array($args['orderby'], $allowed_orderby, true) ? $args['orderby'] : 'completed_at';
         $order = strtoupper($args['order']) === 'ASC' ? 'ASC' : 'DESC';
 

--- a/src/class-job-payload.php
+++ b/src/class-job-payload.php
@@ -14,6 +14,7 @@ class Job_Payload
     public string $source; // 'wp_cron' | 'action_scheduler'
     public int $action_id;
     public string $group;
+    public string $lane;
 
     public function __construct(array $data = [])
     {
@@ -27,6 +28,7 @@ class Job_Payload
         $this->source    = $data['source'] ?? 'wp_cron';
         $this->action_id = $data['action_id'] ?? 0;
         $this->group     = $data['group'] ?? '';
+        $this->lane      = $data['lane'] ?? ($this->source === 'action_scheduler' ? 'action_scheduler' : 'wp_cron');
     }
 
     public function to_json(): string
@@ -42,6 +44,7 @@ class Job_Payload
             'source'    => $this->source,
             'action_id' => $this->action_id,
             'group'     => $this->group,
+            'lane'      => $this->lane,
         ]);
     }
 

--- a/src/class-worker-process.php
+++ b/src/class-worker-process.php
@@ -265,7 +265,7 @@ class Worker_Process
     private function spawn_batch(array $payloads, int $worker_id, string $lane = 'wp_cron'): void
     {
         $json_array = array_map(
-            fn($p) => json_decode($p->to_json(), true),
+            fn($p) => array_merge(json_decode($p->to_json(), true), ['lane' => $lane]),
             $payloads
         );
         $json_data = json_encode($json_array);


### PR DESCRIPTION
## Summary

Added additive qw_job_log columns for scheduled, started, completed, wait, execution, lane, and Action Scheduler action IDs; passed lane through worker batches and serialized payloads; surfaced wait, execution, lane, and action ID in the job list table.

## Files Changed

src/class-job-executor.php,src/class-job-list-table.php,src/class-job-log.php,src/class-job-payload.php,src/class-worker-process.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l src/class-job-log.php src/class-job-executor.php src/class-worker-process.php src/class-job-payload.php; php -l src/class-job-list-table.php; git diff --check

Resolves #20


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 2m and 87,917 tokens on this as a headless worker.