### PR TITLE
GH#22: test: add queue routing regression coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
       "src/class-job-list-table.php"
     ]
   },
+  "scripts": {
+    "test:regression": "php tests/regression.php"
+  },
   "config": {
     "optimize-autoloader": true,
     "classmap-authoritative": true,

--- a/src/class-cli-commands.php
+++ b/src/class-cli-commands.php
@@ -6,14 +6,6 @@ use WP_CLI;
 
 class CLI_Commands
 {
-    private const BYPASS_CRON_HOOKS = [
-        'wp_version_check',
-        'wp_update_plugins',
-        'wp_update_themes',
-        'action_scheduler_run_queue',
-        'action_scheduler_run_cleanup',
-    ];
-
     /**
      * Show queue worker status.
      *
@@ -127,12 +119,12 @@ class CLI_Commands
                 $seen_cron_signatures = [];
                 foreach ($crons as $timestamp => $hooks) {
                     foreach ($hooks as $hook => $events) {
-                        if (in_array($hook, self::BYPASS_CRON_HOOKS, true)) {
+                        if (Cron_Event_Filter::should_bypass($hook)) {
                             continue;
                         }
 
                         foreach ($events as $key => $event) {
-                            $signature = $this->cron_event_signature($hook, $event, (int) $timestamp);
+                            $signature = Cron_Event_Filter::signature($hook, $event, (int) $timestamp);
                             if (isset($seen_cron_signatures[$signature])) {
                                 continue;
                             }
@@ -199,16 +191,4 @@ class CLI_Commands
         WP_CLI::success('Sent restart signal to queue worker. systemd will restart it.');
     }
 
-    private function cron_event_signature(string $hook, array $event, int $timestamp): string
-    {
-        $event_timestamp = empty($event['schedule']) ? $timestamp : 0;
-
-        return sprintf(
-            '%s:%s:%d:%s',
-            $hook,
-            $event['schedule'] ?? '',
-            $event_timestamp,
-            md5(serialize($event['args'] ?? []))
-        );
-    }
 }

--- a/src/class-cron-event-filter.php
+++ b/src/class-cron-event-filter.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace QueueWorker;
+
+class Cron_Event_Filter
+{
+    private const BYPASS_HOOKS = [
+        'wp_version_check',
+        'wp_update_plugins',
+        'wp_update_themes',
+        'action_scheduler_run_queue',
+        'action_scheduler_run_cleanup',
+    ];
+
+    public static function should_bypass(string $hook): bool
+    {
+        return in_array($hook, self::BYPASS_HOOKS, true);
+    }
+
+    public static function signature(string $hook, array $event, int $timestamp): string
+    {
+        $event_timestamp = empty($event['schedule']) ? $timestamp : 0;
+
+        return sprintf(
+            '%s:%s:%d:%s',
+            $hook,
+            $event['schedule'] ?? '',
+            $event_timestamp,
+            md5(serialize($event['args'] ?? []))
+        );
+    }
+}

--- a/src/class-cron-interceptor.php
+++ b/src/class-cron-interceptor.php
@@ -4,14 +4,6 @@ namespace QueueWorker;
 
 class Cron_Interceptor
 {
-    private static array $bypass_hooks = [
-        'wp_version_check',
-        'wp_update_plugins',
-        'wp_update_themes',
-        'action_scheduler_run_queue',
-        'action_scheduler_run_cleanup',
-    ];
-
     public static function register(): void
     {
         add_action('schedule_event', [__CLASS__, 'on_schedule_event']);
@@ -23,7 +15,7 @@ class Cron_Interceptor
             return;
         }
 
-        if (in_array($event->hook, self::$bypass_hooks, true)) {
+        if (Cron_Event_Filter::should_bypass($event->hook)) {
             return;
         }
 

--- a/src/class-worker-process.php
+++ b/src/class-worker-process.php
@@ -560,18 +560,12 @@ class Worker_Process
                         continue;
                     }
                     foreach ($hooks as $hook => $events) {
-                        if (in_array($hook, [
-                            'wp_version_check',
-                            'wp_update_plugins',
-                            'wp_update_themes',
-                            'action_scheduler_run_queue',
-                            'action_scheduler_run_cleanup',
-                        ], true)) {
+                        if (Cron_Event_Filter::should_bypass($hook)) {
                             continue;
                         }
 
                         foreach ($events as $event) {
-                            $signature = $this->cron_event_signature($hook, $event, (int) $timestamp);
+                            $signature = Cron_Event_Filter::signature($hook, $event, (int) $timestamp);
                             if (isset($seen_cron_signatures[$signature])) {
                                 continue;
                             }
@@ -905,19 +899,6 @@ class Worker_Process
     private function running_action_scheduler_count(): int
     {
         return array_sum($this->running_action_scheduler_counts());
-    }
-
-    private function cron_event_signature(string $hook, array $event, int $timestamp): string
-    {
-        $event_timestamp = empty($event['schedule']) ? $timestamp : 0;
-
-        return sprintf(
-            '%s:%s:%d:%s',
-            $hook,
-            $event['schedule'] ?? '',
-            $event_timestamp,
-            md5(serialize($event['args'] ?? []))
-        );
     }
 
     /**

--- a/tests/regression.php
+++ b/tests/regression.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Workerman {
+    class Worker
+    {
+        public int $id = 0;
+
+        public static function log(string $message): void
+        {
+        }
+
+        public static function stopAll(): void
+        {
+        }
+    }
+
+    class Timer
+    {
+        public static int $next_id = 1;
+
+        public static function add($delay, callable $callback, array $args = [], bool $persistent = true): int
+        {
+            return self::$next_id++;
+        }
+    }
+}
+
+namespace {
+    use QueueWorker\Config;
+    use QueueWorker\Cron_Event_Filter;
+    use QueueWorker\Job_Payload;
+    use QueueWorker\Worker_Process;
+
+    $_SERVER['HTTP_HOST'] = 'example.test';
+
+    $GLOBALS['test_crons'] = [];
+    $GLOBALS['test_current_blog_id'] = 1;
+    $GLOBALS['test_switched_blogs'] = [];
+
+    class Test_WPDB
+    {
+        public string $prefix = 'wp_';
+        public string $base_prefix = 'wp_';
+
+        public function prepare(string $query, ...$args): string
+        {
+            return vsprintf(str_replace('%s', "'%s'", $query), $args);
+        }
+
+        public function esc_like(string $text): string
+        {
+            return $text;
+        }
+
+        public function get_var(string $query): ?string
+        {
+            return null;
+        }
+
+        public function query(string $query): int
+        {
+            return 1;
+        }
+    }
+
+    $GLOBALS['wpdb'] = new Test_WPDB();
+
+    function get_site_url(): string
+    {
+        return 'https://example.test';
+    }
+
+    function get_current_blog_id(): int
+    {
+        return (int) $GLOBALS['test_current_blog_id'];
+    }
+
+    function wp_get_schedules(): array
+    {
+        return [
+            'hourly' => ['interval' => 3600],
+        ];
+    }
+
+    function get_sites(array $args): array
+    {
+        return [1];
+    }
+
+    function switch_to_blog(int $site_id): void
+    {
+        $GLOBALS['test_current_blog_id'] = $site_id;
+        $GLOBALS['test_switched_blogs'][] = $site_id;
+    }
+
+    function restore_current_blog(): void
+    {
+        $GLOBALS['test_current_blog_id'] = 1;
+    }
+
+    function wp_cache_delete(string $key, string $group): void
+    {
+    }
+
+    function _get_cron_array(): array
+    {
+        return $GLOBALS['test_crons'];
+    }
+
+    function assert_true(bool $condition, string $message): void
+    {
+        if (!$condition) {
+            throw new RuntimeException($message);
+        }
+    }
+
+    function assert_same($expected, $actual, string $message): void
+    {
+        if ($expected !== $actual) {
+            throw new RuntimeException($message . ' Expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+        }
+    }
+
+    function private_property(object $object, string $property)
+    {
+        $reflection = new ReflectionProperty($object, $property);
+        $reflection->setAccessible(true);
+
+        return $reflection->getValue($object);
+    }
+
+    function invoke_private(object $object, string $method, array $args = [])
+    {
+        $reflection = new ReflectionMethod($object, $method);
+        $reflection->setAccessible(true);
+
+        return $reflection->invokeArgs($object, $args);
+    }
+
+    require_once __DIR__ . '/../src/class-config.php';
+    require_once __DIR__ . '/../src/class-cron-event-filter.php';
+    require_once __DIR__ . '/../src/class-job-payload.php';
+    require_once __DIR__ . '/../src/class-worker-process.php';
+
+    $payload = new Job_Payload([
+        'site_id'   => 7,
+        'site_url'  => 'https://tenant.example.test',
+        'hook'      => 'as_hook',
+        'args'      => ['order_id' => 123],
+        'timestamp' => 1710000000,
+        'source'    => 'action_scheduler',
+        'action_id' => 44,
+        'group'     => 'checkout',
+    ]);
+    $decoded = json_decode($payload->to_json(), true);
+    assert_same('checkout', $decoded['group'], 'Action Scheduler group must be serialized');
+    assert_true(str_contains($payload->tracking_key(), ':checkout:'), 'Action Scheduler group must be part of the tracking key');
+
+    putenv('QUEUE_WORKER_AS_LANES=' . json_encode([
+        [
+            'name' => 'checkout_lane',
+            'sites' => [7],
+            'groups' => ['checkout'],
+            'hooks' => ['as_hook'],
+            'max_concurrent' => 2,
+            'max_batch_size' => 3,
+        ],
+    ]));
+    $worker = new Worker_Process(__FILE__, 'example.test', __FILE__);
+    assert_same('checkout_lane', invoke_private($worker, 'action_scheduler_lane_for', [$payload]), 'AS lane must match by site, group, and hook');
+    assert_same('action_scheduler', invoke_private($worker, 'action_scheduler_lane_for', [new Job_Payload([
+        'site_id' => 7,
+        'site_url' => 'https://tenant.example.test',
+        'hook' => 'other_hook',
+        'args' => [],
+        'timestamp' => 1710000000,
+        'source' => 'action_scheduler',
+        'group' => 'checkout',
+    ])]), 'AS lane must not match when hook differs');
+
+    putenv('QUEUE_WORKER_AS_RESCAN_INTERVAL');
+    assert_same(5, Config::action_scheduler_rescan_interval(), 'AS rescan interval must default to five seconds');
+    putenv('QUEUE_WORKER_AS_RESCAN_INTERVAL=12');
+    assert_same(12, Config::action_scheduler_rescan_interval(), 'AS rescan interval must be configurable');
+    putenv('QUEUE_WORKER_AS_RESCAN_INTERVAL=0');
+    assert_same(1, Config::action_scheduler_rescan_interval(), 'AS rescan interval must be clamped to at least one second');
+
+    assert_true(Cron_Event_Filter::should_bypass('wp_update_plugins'), 'Bypass hook must be skipped by shared cron filter');
+    assert_true(Cron_Event_Filter::should_bypass('action_scheduler_run_queue'), 'Action Scheduler queue runner must be skipped by shared cron filter');
+    assert_true(!Cron_Event_Filter::should_bypass('custom_hook'), 'Custom hooks must not be bypassed by shared cron filter');
+    assert_same(
+        Cron_Event_Filter::signature('custom_hook', ['schedule' => 'hourly', 'args' => ['a' => 1]], 100),
+        Cron_Event_Filter::signature('custom_hook', ['schedule' => 'hourly', 'args' => ['a' => 1]], 200),
+        'Recurring cron duplicates must collapse across timestamps for the same hook, schedule, and args'
+    );
+
+    $GLOBALS['test_crons'] = [
+        100 => [
+            'wp_update_plugins' => [
+                'ignored' => ['schedule' => 'hourly', 'args' => []],
+            ],
+            'custom_hook' => [
+                'first' => ['schedule' => 'hourly', 'args' => ['a' => 1]],
+            ],
+        ],
+        200 => [
+            'custom_hook' => [
+                'duplicate' => ['schedule' => 'hourly', 'args' => ['a' => 1]],
+            ],
+        ],
+    ];
+    $scan_worker = new Worker_Process(__FILE__, 'example.test', __FILE__);
+    invoke_private($scan_worker, 'rescan_all_jobs');
+    $pending = private_property($scan_worker, 'pending_timers');
+    assert_same(1, count($pending), 'Worker scan must skip bypass hooks and collapse duplicate cron signatures');
+    $scheduled_payload = private_property($scan_worker, 'pending_timers') ? array_key_first($pending) : '';
+    assert_true(str_contains($scheduled_payload, 'custom_hook'), 'Worker scan must schedule the non-bypassed hook');
+
+    echo "Regression tests passed.\n";
+}


### PR DESCRIPTION
## Summary

Added a standalone regression test command covering Action Scheduler group serialization/tracking, lane matching by site/group/hook, cron duplicate signature collapse, shared bypass hook filtering for worker/CLI paths, and configurable AS rescan interval defaults. Extracted shared cron filter/signature helpers so worker scans, CLI populate, and schedule interception use the same behavior.

## Files Changed

composer.json,src/class-cli-commands.php,src/class-cron-event-filter.php,src/class-cron-interceptor.php,src/class-worker-process.php,tests/regression.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** composer test:regression; composer validate --no-check-publish; php -l src/class-cron-event-filter.php src/class-cron-interceptor.php src/class-cli-commands.php src/class-worker-process.php tests/regression.php

Resolves #22


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 3m and 69,011 tokens on this as a headless worker.