### PR TITLE
GH#16: feat: make bypassed cron hooks configurable

### DIFF
--- a/bin/scan-cron.php
+++ b/bin/scan-cron.php
@@ -51,6 +51,7 @@ if (!class_exists('QueueWorker\\Config')) {
 }
 
 use QueueWorker\Bootstrap;
+use QueueWorker\Cron_Event_Filter;
 use QueueWorker\Job_Payload;
 
 $site_root = $site_autoload ? dirname($site_autoload, 2) : dirname(__DIR__);
@@ -84,14 +85,6 @@ if (!$is_sovereign_tenant && $site_id !== get_current_blog_id()) {
 wp_cache_delete('cron', 'options');
 wp_cache_delete('alloptions', 'options');
 
-$bypass_hooks = [
-    'wp_version_check',
-    'wp_update_plugins',
-    'wp_update_themes',
-    'action_scheduler_run_queue',
-    'action_scheduler_run_cleanup',
-];
-
 $payloads = [];
 $crons = _get_cron_array();
 if (is_array($crons)) {
@@ -101,7 +94,7 @@ if (is_array($crons)) {
             continue;
         }
         foreach ($hooks as $hook => $events) {
-            if (in_array($hook, $bypass_hooks, true)) {
+            if (Cron_Event_Filter::should_bypass($hook)) {
                 continue;
             }
             foreach ($events as $event) {

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -4,6 +4,14 @@ namespace QueueWorker;
 
 class Config
 {
+    private const DEFAULT_BYPASS_CRON_HOOKS = [
+        'wp_version_check',
+        'wp_update_plugins',
+        'wp_update_themes',
+        'action_scheduler_run_queue',
+        'action_scheduler_run_cleanup',
+    ];
+
     public static function socket_path(): string
     {
         return self::get('QUEUE_WORKER_SOCKET_PATH', '/tmp/the-perfect-wp-cron.sock');
@@ -70,6 +78,14 @@ class Config
     public static function low_priority_hooks(): array
     {
         return self::normalize_string_list(self::get('QUEUE_WORKER_LOW_PRIORITY_HOOKS', []));
+    }
+
+    public static function bypass_cron_hooks(): array
+    {
+        return array_values(array_unique(array_merge(
+            self::DEFAULT_BYPASS_CRON_HOOKS,
+            self::normalize_string_list(self::get('QUEUE_WORKER_BYPASS_CRON_HOOKS', []))
+        )));
     }
 
     public static function max_batch_size(): int

--- a/src/class-cron-event-filter.php
+++ b/src/class-cron-event-filter.php
@@ -4,17 +4,9 @@ namespace QueueWorker;
 
 class Cron_Event_Filter
 {
-    private const BYPASS_HOOKS = [
-        'wp_version_check',
-        'wp_update_plugins',
-        'wp_update_themes',
-        'action_scheduler_run_queue',
-        'action_scheduler_run_cleanup',
-    ];
-
     public static function should_bypass(string $hook): bool
     {
-        return in_array($hook, self::BYPASS_HOOKS, true);
+        return in_array($hook, Config::bypass_cron_hooks(), true);
     }
 
     public static function signature(string $hook, array $event, int $timestamp): string

--- a/tests/regression.php
+++ b/tests/regression.php
@@ -188,6 +188,11 @@ namespace {
     assert_true(Cron_Event_Filter::should_bypass('wp_update_plugins'), 'Bypass hook must be skipped by shared cron filter');
     assert_true(Cron_Event_Filter::should_bypass('action_scheduler_run_queue'), 'Action Scheduler queue runner must be skipped by shared cron filter');
     assert_true(!Cron_Event_Filter::should_bypass('custom_hook'), 'Custom hooks must not be bypassed by shared cron filter');
+    putenv('QUEUE_WORKER_BYPASS_CRON_HOOKS=custom_hook, extra_hook');
+    assert_true(Cron_Event_Filter::should_bypass('wp_update_plugins'), 'Default bypass hooks must remain active when custom hooks are configured');
+    assert_true(Cron_Event_Filter::should_bypass('custom_hook'), 'Configured bypass hook must be skipped by shared cron filter');
+    assert_true(Cron_Event_Filter::should_bypass('extra_hook'), 'Comma-separated bypass hooks must be normalized');
+    putenv('QUEUE_WORKER_BYPASS_CRON_HOOKS');
     assert_same(
         Cron_Event_Filter::signature('custom_hook', ['schedule' => 'hourly', 'args' => ['a' => 1]], 100),
         Cron_Event_Filter::signature('custom_hook', ['schedule' => 'hourly', 'args' => ['a' => 1]], 200),


### PR DESCRIPTION
## Summary

Added Config::bypass_cron_hooks() with backwards-compatible defaults merged with QUEUE_WORKER_BYPASS_CRON_HOOKS, routed the shared Cron_Event_Filter and sovereign scan path through that canonical source, and added regression coverage for custom merged bypass hooks.

## Files Changed

bin/scan-cron.php,src/class-config.php,src/class-cron-event-filter.php,tests/regression.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l src/class-config.php src/class-worker-process.php src/class-cli-commands.php src/class-cron-interceptor.php && php -l src/class-cron-event-filter.php bin/scan-cron.php tests/regression.php && php tests/regression.php

Resolves #16


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 2m and 81,368 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cron hook bypass filtering is now configurable, enabling users to specify additional WP-Cron hooks to bypass through environment settings while system defaults remain active.

* **Refactor**
  * Cron event filtering updated to use dynamic configuration instead of hardcoded bypass lists.

* **Tests**
  * Added regression tests verifying custom bypass hooks integrate correctly with system defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->