### PR TITLE
GH#14: feat: add cron dedupe CLI command

### DIFF
--- a/src/class-cli-commands.php
+++ b/src/class-cli-commands.php
@@ -214,6 +214,191 @@ class CLI_Commands
     }
 
     /**
+     * Report or remove duplicate persisted WP-Cron events.
+     *
+     * Duplicate recurring events can accumulate when long-running event-loop
+     * execution, wp_reschedule_event(), backlog catch-up, and plugin bootstrap
+     * scheduling all touch the same hook. This command groups events by site,
+     * hook, schedule, and args; keeps the earliest timestamp; and optionally
+     * removes later timestamps for identical recurring/event signatures.
+     *
+     * ## OPTIONS
+     *
+     * --dry-run
+     * : Report duplicate groups without modifying cron options.
+     *
+     * --apply
+     * : Remove later duplicate events with wp_unschedule_event().
+     *
+     * ## EXAMPLES
+     *
+     *     wp queue dedupe-cron --dry-run
+     *     wp queue dedupe-cron --apply
+     *
+     * @subcommand dedupe-cron
+     */
+    public function dedupe_cron($args, $assoc_args): void
+    {
+        $dry_run = (bool) ($assoc_args['dry-run'] ?? false);
+        $apply   = (bool) ($assoc_args['apply'] ?? false);
+
+        if ($dry_run === $apply) {
+            WP_CLI::error('Specify exactly one of --dry-run or --apply.');
+        }
+
+        $totals = [
+            'sites'    => 0,
+            'groups'   => 0,
+            'retained' => 0,
+            'removed'  => 0,
+        ];
+        $rows = [];
+
+        foreach ($this->cron_dedupe_site_ids() as $site_id) {
+            $site_id = (int) $site_id;
+            $totals['sites']++;
+
+            if (is_multisite()) {
+                switch_to_blog($site_id);
+            }
+
+            try {
+                $report = $this->cron_dedupe_site_report($site_id, $apply);
+            } finally {
+                if (is_multisite()) {
+                    restore_current_blog();
+                }
+            }
+
+            $totals['groups']   += $report['groups'];
+            $totals['retained'] += $report['retained'];
+            $totals['removed']  += $report['removed'];
+            $rows = array_merge($rows, $report['rows']);
+        }
+
+        WP_CLI::log($apply ? 'Duplicate WP-Cron cleanup applied.' : 'Duplicate WP-Cron dry-run report. No changes were made.');
+        WP_CLI::log('Grouping key: site_id + hook + schedule + args; earliest timestamp retained.');
+
+        if (!empty($rows)) {
+            \WP_CLI\Utils\format_items('table', $rows, ['site_id', 'hook', 'schedule', 'duplicates', 'retained_timestamp', 'removed_timestamps']);
+        } else {
+            WP_CLI::log('No duplicate WP-Cron events found.');
+        }
+
+        WP_CLI::log(sprintf('Sites scanned: %d', $totals['sites']));
+        WP_CLI::log(sprintf('Duplicate groups: %d', $totals['groups']));
+        WP_CLI::log(sprintf('Retained events: %d', $totals['retained']));
+        WP_CLI::log(sprintf('%s events: %d', $apply ? 'Removed' : 'Would remove', $totals['removed']));
+
+        WP_CLI::success($apply ? 'Cron dedupe complete.' : 'Cron dedupe dry-run complete.');
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function cron_dedupe_site_ids(): array
+    {
+        if (!is_multisite()) {
+            return [get_current_blog_id()];
+        }
+
+        return array_map('intval', get_sites(['number' => 0, 'fields' => 'ids']));
+    }
+
+    /**
+     * @return array{groups: int, retained: int, removed: int, rows: list<array<string, int|string>>}
+     */
+    private function cron_dedupe_site_report(int $site_id, bool $apply): array
+    {
+        $crons = _get_cron_array();
+        if (!is_array($crons)) {
+            return ['groups' => 0, 'retained' => 0, 'removed' => 0, 'rows' => []];
+        }
+
+        $groups = $this->cron_duplicate_groups($crons);
+        $report = ['groups' => 0, 'retained' => 0, 'removed' => 0, 'rows' => []];
+
+        foreach ($groups as $group) {
+            if (count($group['events']) < 2) {
+                continue;
+            }
+
+            $duplicates = array_slice($group['events'], 1);
+            $removed_timestamps = [];
+
+            foreach ($duplicates as $event) {
+                $removed_timestamps[] = (int) $event['timestamp'];
+
+                if ($apply) {
+                    wp_unschedule_event((int) $event['timestamp'], $group['hook'], $group['args']);
+                }
+            }
+
+            $duplicate_count = count($duplicates);
+            $report['groups']++;
+            $report['retained']++;
+            $report['removed'] += $duplicate_count;
+            $report['rows'][] = [
+                'site_id'            => $site_id,
+                'hook'               => $group['hook'],
+                'schedule'           => $group['schedule'] !== '' ? $group['schedule'] : '(one-shot)',
+                'duplicates'         => $duplicate_count,
+                'retained_timestamp' => (int) $group['events'][0]['timestamp'],
+                'removed_timestamps' => implode(',', array_map('strval', $removed_timestamps)),
+            ];
+        }
+
+        return $report;
+    }
+
+    /**
+     * @return array<string, array{hook: string, schedule: string, args: array, events: list<array{timestamp: int}>}>
+     */
+    private function cron_duplicate_groups(array $crons): array
+    {
+        $groups = [];
+
+        foreach ($crons as $timestamp => $hooks) {
+            if (!is_array($hooks)) {
+                continue;
+            }
+
+            foreach ($hooks as $hook => $events) {
+                if (!is_array($events)) {
+                    continue;
+                }
+
+                foreach ($events as $event) {
+                    if (!is_array($event)) {
+                        continue;
+                    }
+
+                    $signature = Cron_Event_Filter::signature((string) $hook, $event, (int) $timestamp);
+                    if (!isset($groups[$signature])) {
+                        $groups[$signature] = [
+                            'hook'     => (string) $hook,
+                            'schedule' => (string) ($event['schedule'] ?? ''),
+                            'args'     => $event['args'] ?? [],
+                            'events'   => [],
+                        ];
+                    }
+
+                    $groups[$signature]['events'][] = ['timestamp' => (int) $timestamp];
+                }
+            }
+        }
+
+        foreach ($groups as $signature => $group) {
+            usort($group['events'], static function (array $left, array $right): int {
+                return $left['timestamp'] <=> $right['timestamp'];
+            });
+            $groups[$signature] = $group;
+        }
+
+        return $groups;
+    }
+
+    /**
      * Report pending, overdue, and failed Action Scheduler actions by hook/group.
      *
      * ## OPTIONS

--- a/tests/regression.php
+++ b/tests/regression.php
@@ -25,6 +25,42 @@ namespace Workerman {
     }
 }
 
+namespace WP_CLI\Utils {
+    function format_items(string $format, array $items, array $fields): void
+    {
+    }
+}
+
+namespace {
+    class WP_CLI
+    {
+        public static array $errors = [];
+        public static array $logs = [];
+        public static array $successes = [];
+
+        public static function error(string $message): void
+        {
+            self::$errors[] = $message;
+            throw new RuntimeException($message);
+        }
+
+        public static function warning(string $message): void
+        {
+            self::$logs[] = 'WARNING: ' . $message;
+        }
+
+        public static function log(string $message): void
+        {
+            self::$logs[] = $message;
+        }
+
+        public static function success(string $message): void
+        {
+            self::$successes[] = $message;
+        }
+    }
+}
+
 namespace {
     use QueueWorker\Config;
     use QueueWorker\Cron_Event_Filter;
@@ -36,6 +72,7 @@ namespace {
     $GLOBALS['test_crons'] = [];
     $GLOBALS['test_current_blog_id'] = 1;
     $GLOBALS['test_switched_blogs'] = [];
+    $GLOBALS['test_unscheduled_events'] = [];
 
     class Test_WPDB
     {
@@ -75,6 +112,11 @@ namespace {
         return (int) $GLOBALS['test_current_blog_id'];
     }
 
+    function is_multisite(): bool
+    {
+        return false;
+    }
+
     function wp_get_schedules(): array
     {
         return [
@@ -105,6 +147,17 @@ namespace {
     function _get_cron_array(): array
     {
         return $GLOBALS['test_crons'];
+    }
+
+    function wp_unschedule_event(int $timestamp, string $hook, array $args = []): bool
+    {
+        $GLOBALS['test_unscheduled_events'][] = [
+            'timestamp' => $timestamp,
+            'hook'      => $hook,
+            'args'      => $args,
+        ];
+
+        return true;
     }
 
     function assert_true(bool $condition, string $message): void
@@ -139,6 +192,7 @@ namespace {
 
     require_once __DIR__ . '/../src/class-config.php';
     require_once __DIR__ . '/../src/class-cron-event-filter.php';
+    require_once __DIR__ . '/../src/class-cli-commands.php';
     require_once __DIR__ . '/../src/class-job-payload.php';
     require_once __DIR__ . '/../src/class-worker-process.php';
 
@@ -220,6 +274,55 @@ namespace {
     assert_same(1, count($pending), 'Worker scan must skip bypass hooks and collapse duplicate cron signatures');
     $scheduled_payload = private_property($scan_worker, 'pending_timers') ? array_key_first($pending) : '';
     assert_true(str_contains($scheduled_payload, 'custom_hook'), 'Worker scan must schedule the non-bypassed hook');
+
+    $GLOBALS['test_crons'] = [
+        300 => [
+            'recurring_hook' => [
+                'first' => ['schedule' => 'hourly', 'args' => ['a' => 1]],
+            ],
+            'one_shot_hook' => [
+                'one' => ['schedule' => '', 'args' => ['a' => 1]],
+            ],
+        ],
+        100 => [
+            'recurring_hook' => [
+                'earliest' => ['schedule' => 'hourly', 'args' => ['a' => 1]],
+            ],
+        ],
+        200 => [
+            'recurring_hook' => [
+                'middle' => ['schedule' => 'hourly', 'args' => ['a' => 1]],
+                'different_args' => ['schedule' => 'hourly', 'args' => ['a' => 2]],
+            ],
+            'one_shot_hook' => [
+                'two' => ['schedule' => '', 'args' => ['a' => 1]],
+            ],
+        ],
+    ];
+    $cli = new QueueWorker\CLI_Commands();
+    $groups = invoke_private($cli, 'cron_duplicate_groups', [$GLOBALS['test_crons']]);
+    $duplicate_groups = array_values(array_filter($groups, static function (array $group): bool {
+        return count($group['events']) > 1;
+    }));
+    assert_same(1, count($duplicate_groups), 'Only recurring events with identical hook, schedule, and args should be duplicate groups');
+    assert_same('recurring_hook', $duplicate_groups[0]['hook'], 'Duplicate group must preserve the hook');
+    assert_same(100, $duplicate_groups[0]['events'][0]['timestamp'], 'Earliest duplicate timestamp must be retained');
+    assert_same(200, $duplicate_groups[0]['events'][1]['timestamp'], 'Later duplicate timestamps must be sorted for removal');
+    assert_same(300, $duplicate_groups[0]['events'][2]['timestamp'], 'Latest duplicate timestamp must be sorted last');
+
+    $GLOBALS['test_unscheduled_events'] = [];
+    $dry_report = invoke_private($cli, 'cron_dedupe_site_report', [1, false]);
+    assert_same(1, $dry_report['groups'], 'Dry-run must report one duplicate recurring group');
+    assert_same(1, $dry_report['retained'], 'Dry-run must retain one event per duplicate group');
+    assert_same(2, $dry_report['removed'], 'Dry-run must count later duplicate events as removable');
+    assert_same([], $GLOBALS['test_unscheduled_events'], 'Dry-run must not unschedule events');
+
+    $apply_report = invoke_private($cli, 'cron_dedupe_site_report', [1, true]);
+    assert_same(2, $apply_report['removed'], 'Apply must count removed duplicate events');
+    assert_same([
+        ['timestamp' => 200, 'hook' => 'recurring_hook', 'args' => ['a' => 1]],
+        ['timestamp' => 300, 'hook' => 'recurring_hook', 'args' => ['a' => 1]],
+    ], $GLOBALS['test_unscheduled_events'], 'Apply must unschedule only later duplicate recurring events');
 
     echo "Regression tests passed.\n";
 }


### PR DESCRIPTION
## Summary

- Adds `wp queue dedupe-cron --dry-run|--apply` for duplicate persisted WP-Cron events.
- Scans all multisite sites, groups recurring events by hook/schedule/args, keeps the earliest timestamp, and removes later duplicates only when `--apply` is specified.
- Adds regression coverage for grouping, dry-run safety, and apply unscheduling behavior.

Resolves #14

## Verification

- `php -l src/class-cli-commands.php && php -l src/class-job-executor.php && php -l src/class-worker-process.php && php -l src/class-cron-interceptor.php && php -l tests/regression.php`
- `composer validate --no-check-publish`
- `composer test:regression`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 7m and 147,668 tokens on this as a headless worker.