### PR TITLE
fix: schedule due jobs with positive timer delay

### DIFF
--- a/src/class-worker-process.php
+++ b/src/class-worker-process.php
@@ -209,7 +209,10 @@ class Worker_Process
         if (isset($this->pending_timers[$key])) {
             return;
         }
-        $delay = max(0, $payload->timestamp - time());
+        // Workerman timers must use a positive interval. Due or overdue
+        // payloads still need to run immediately, so schedule them on the next
+        // event-loop tick instead of passing 0 to Timer::add().
+        $delay = max(0.001, $payload->timestamp - time());
         $timer_id = Timer::add($delay, fn($p) => $this->execute_job($p), [$payload], false);
         $this->pending_timers[$key] = $timer_id;
         $this->pending_timer_payloads[$key] = $payload;

--- a/tests/regression.php
+++ b/tests/regression.php
@@ -17,9 +17,12 @@ namespace Workerman {
     class Timer
     {
         public static int $next_id = 1;
+        public static array $delays = [];
 
         public static function add($delay, callable $callback, array $args = [], bool $persistent = true): int
         {
+            self::$delays[] = $delay;
+
             return self::$next_id++;
         }
     }
@@ -251,6 +254,19 @@ namespace {
         'source' => 'action_scheduler',
         'group' => 'checkout',
     ])]), 'AS lane must not match when hook differs');
+
+    \Workerman\Timer::$delays = [];
+    invoke_private($worker, 'schedule_timer', [new Job_Payload([
+        'site_id' => 7,
+        'site_url' => 'https://tenant.example.test',
+        'hook' => 'due_as_hook',
+        'args' => [],
+        'timestamp' => time() - 10,
+        'source' => 'action_scheduler',
+        'action_id' => 45,
+        'group' => 'checkout',
+    ])]);
+    assert_same(0.001, \Workerman\Timer::$delays[0] ?? null, 'Due Action Scheduler payloads must use a positive near-immediate timer delay');
 
     putenv('QUEUE_WORKER_AS_RESCAN_INTERVAL');
     assert_same(5, Config::action_scheduler_rescan_interval(), 'AS rescan interval must default to five seconds');


### PR DESCRIPTION
## Summary

- Clamp due/overdue job timer delays to a positive near-immediate interval before calling `Workerman\Timer::add()`.
- Add a regression assertion that due Action Scheduler payloads never schedule a zero-second Workerman timer.

## Production evidence

Observed on the production queue worker while investigating delayed provisioning after checkout:

```text
Exception: bad time_interval
... Workerman\Timer::add(0, ...)
... QueueWorker\Worker_Process->schedule_timer()
... QueueWorker\Worker_Process->rescan_action_scheduler_jobs()
```

The socket and worker service were up, but due `wu_async_publish_pending_site` Action Scheduler jobs stayed pending. Workerman rejects a zero interval, so due jobs need to be scheduled on the next event-loop tick rather than with `0`.

## Verification

```bash
php -l src/class-worker-process.php
php -l tests/regression.php
php tests/regression.php
```

Result: syntax checks passed; regression tests passed.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.88 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced scheduler reliability by correcting the timer delay calculation for due and overdue tasks. Tasks now execute consistently on the next event loop iteration, preventing timing-related issues.

* **Tests**
  * Added regression tests to validate timer scheduling behavior for due tasks and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->