### PR TITLE
fix: preserve switched blog payload site ids

### DIFF
--- a/src/class-job-payload.php
+++ b/src/class-job-payload.php
@@ -150,6 +150,10 @@ class Job_Payload
             return (int) WU_MT_SOVEREIGN_TENANT;
         }
 
+        if (function_exists('ms_is_switched') && ms_is_switched()) {
+            return get_current_blog_id();
+        }
+
         $host = strtolower(trim((string) ($_SERVER['HTTP_HOST'] ?? '')));
         if ($host !== '' && defined('WP_CONTENT_DIR')) {
             $path = WP_CONTENT_DIR . '/site-registry.data.json';

--- a/tests/regression.php
+++ b/tests/regression.php
@@ -264,6 +264,18 @@ namespace {
     ])]), 'AS lane must not match when hook differs');
 
     \Workerman\Timer::$delays = [];
+    $registry_content_dir = sys_get_temp_dir() . '/qw-regression-content-' . getmypid();
+    if (!is_dir($registry_content_dir)) {
+        assert_true(mkdir($registry_content_dir, 0777, true), 'Registry fixture directory must be created');
+    }
+    if (!defined('WP_CONTENT_DIR')) {
+        define('WP_CONTENT_DIR', $registry_content_dir);
+    }
+    assert_true(false !== file_put_contents(WP_CONTENT_DIR . '/site-registry.data.json', json_encode([
+        'domain_index' => [
+            'example.test' => 7,
+        ],
+    ])), 'Registry fixture must be writable');
     $GLOBALS['test_current_blog_id'] = 49;
     $GLOBALS['test_ms_switched'] = true;
     $switched_payload = new Job_Payload([

--- a/tests/regression.php
+++ b/tests/regression.php
@@ -79,6 +79,7 @@ namespace {
     $GLOBALS['test_actions'] = [];
     $GLOBALS['test_switched_blogs'] = [];
     $GLOBALS['test_unscheduled_events'] = [];
+    $GLOBALS['test_ms_switched'] = false;
 
     class Test_WPDB
     {
@@ -123,6 +124,11 @@ namespace {
         return false;
     }
 
+    function ms_is_switched(): bool
+    {
+        return (bool) $GLOBALS['test_ms_switched'];
+    }
+
     function wp_get_schedules(): array
     {
         return [
@@ -139,11 +145,13 @@ namespace {
     {
         $GLOBALS['test_current_blog_id'] = $site_id;
         $GLOBALS['test_switched_blogs'][] = $site_id;
+        $GLOBALS['test_ms_switched'] = true;
     }
 
     function restore_current_blog(): void
     {
         $GLOBALS['test_current_blog_id'] = 1;
+        $GLOBALS['test_ms_switched'] = false;
     }
 
     function wp_cache_delete(string $key, string $group): void
@@ -256,6 +264,19 @@ namespace {
     ])]), 'AS lane must not match when hook differs');
 
     \Workerman\Timer::$delays = [];
+    $GLOBALS['test_current_blog_id'] = 49;
+    $GLOBALS['test_ms_switched'] = true;
+    $switched_payload = new Job_Payload([
+        'hook' => 'switched_site_hook',
+        'args' => [],
+        'timestamp' => 1710000000,
+        'source' => 'action_scheduler',
+        'action_id' => 46,
+        'group' => 'translate',
+    ]);
+    assert_same(49, $switched_payload->site_id, 'Payload site ID must follow the switched blog during network scans');
+    restore_current_blog();
+
     invoke_private($worker, 'schedule_timer', [new Job_Payload([
         'site_id' => 7,
         'site_url' => 'https://tenant.example.test',


### PR DESCRIPTION
## Summary
- Preserve the active switched blog ID when building queue payloads during multisite scans.
- Keep sovereign tenant handling first, then prefer `ms_is_switched()` / `get_current_blog_id()` before falling back to the domain registry lookup.
- Add a regression test for root-worker scans where `HTTP_HOST` still points at the primary domain while the worker is switched to a tenant blog.

## Why
The production health audit for `superdav42/tgc.church` issue #200 found historical Action Scheduler failures dominated by `no_callbacks_registered`. Target-site callbacks are currently registered when bootstrapped with the correct `--url`, which points to the worker sometimes executing per-site Action Scheduler actions under the wrong site context.

## Verification
```text
php -l src/class-job-payload.php
php -l tests/regression.php
php tests/regression.php
```

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.2 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 4h 1m and 382,089 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved site ID detection when WordPress multisite switching is active, so jobs now use the currently switched site instead of a fallback domain-based lookup.
  * Added coverage for switched-site scenarios to ensure payloads resolve the correct site ID during network scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->