### PR TITLE
GH#42: cover switched blog registry conflict

### DIFF
--- a/tests/regression.php
+++ b/tests/regression.php
@@ -276,6 +276,15 @@ namespace {
             'example.test' => 7,
         ],
     ])), 'Registry fixture must be writable');
+    $registry_payload = new Job_Payload([
+        'hook' => 'registry_site_hook',
+        'args' => [],
+        'timestamp' => 1710000000,
+        'source' => 'action_scheduler',
+        'action_id' => 47,
+        'group' => 'translate',
+    ]);
+    assert_same(7, $registry_payload->site_id, 'Payload site ID must use the registry lookup when not switched');
     $GLOBALS['test_current_blog_id'] = 49;
     $GLOBALS['test_ms_switched'] = true;
     $switched_payload = new Job_Payload([


### PR DESCRIPTION
## Summary

Added regression coverage proving Job_Payload uses the domain registry when unswitched, then preserves the switched blog site ID when the same host maps to another site.

## Files Changed

tests/regression.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** composer test:regression

Resolves #42


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.4 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 1m and 34,674 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for a registry-backed job scenario to verify the computed site ID remains correct when the blog is not switched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->