### PR TITLE
fix: batch job log cleanup

### DIFF
--- a/src/class-job-log.php
+++ b/src/class-job-log.php
@@ -51,6 +51,7 @@ class Job_Log
         self::add_index_if_missing($table, 'lane', 'ALTER TABLE `' . $table . '` ADD KEY `lane` (`lane`)');
         self::add_index_if_missing($table, 'action_id', 'ALTER TABLE `' . $table . '` ADD KEY `action_id` (`action_id`)');
         self::add_index_if_missing($table, 'scheduled_at', 'ALTER TABLE `' . $table . '` ADD KEY `scheduled_at` (`scheduled_at`)');
+        self::add_index_if_missing($table, 'completed_at', 'ALTER TABLE `' . $table . '` ADD KEY `completed_at` (`completed_at`)');
     }
 
     private static function add_column_if_missing(string $table, string $column, string $alter_sql): void
@@ -249,7 +250,7 @@ class Job_Log
         ), ARRAY_A) ?: [];
     }
 
-    public static function cleanup(int $days = 0): int
+    public static function cleanup(int $days = 0, int $batch_size = 10000): int
     {
         global $wpdb;
         $table = self::table();
@@ -258,9 +259,27 @@ class Job_Log
             $days = Config::log_retention();
         }
 
-        return (int) $wpdb->query($wpdb->prepare(
-            "DELETE FROM `$table` WHERE completed_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %d DAY)",
-            $days
-        ));
+        $batch_size = max(1, $batch_size);
+        $total_deleted = 0;
+
+        do {
+            $deleted = $wpdb->query($wpdb->prepare(
+                "DELETE FROM `$table`
+                WHERE completed_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %d DAY)
+                ORDER BY completed_at ASC
+                LIMIT %d",
+                $days,
+                $batch_size
+            ));
+
+            if ($deleted === false) {
+                break;
+            }
+
+            $deleted = (int) $deleted;
+            $total_deleted += $deleted;
+        } while ($deleted === $batch_size);
+
+        return $total_deleted;
     }
 }

--- a/tests/regression.php
+++ b/tests/regression.php
@@ -68,6 +68,7 @@ namespace {
     use QueueWorker\Config;
     use QueueWorker\Cron_Event_Filter;
     use QueueWorker\Cron_Interceptor;
+    use QueueWorker\Job_Log;
     use QueueWorker\Job_Payload;
     use QueueWorker\Worker_Process;
 
@@ -88,6 +89,8 @@ namespace {
     {
         public string $prefix = 'wp_';
         public string $base_prefix = 'wp_';
+        public array $queries = [];
+        public array $query_results = [];
 
         public function prepare(string $query, ...$args): string
         {
@@ -104,9 +107,11 @@ namespace {
             return null;
         }
 
-        public function query(string $query): int
+        public function query(string $query)
         {
-            return 1;
+            $this->queries[] = $query;
+
+            return $this->query_results === [] ? 1 : array_shift($this->query_results);
         }
     }
 
@@ -285,6 +290,7 @@ namespace {
     require_once __DIR__ . '/../src/class-cron-event-filter.php';
     require_once __DIR__ . '/../src/class-cron-interceptor.php';
     require_once __DIR__ . '/../src/class-cli-commands.php';
+    require_once __DIR__ . '/../src/class-job-log.php';
     require_once __DIR__ . '/../src/class-job-payload.php';
     require_once __DIR__ . '/../src/class-job-executor.php';
     require_once __DIR__ . '/../src/class-worker-process.php';
@@ -530,6 +536,15 @@ namespace {
         ['timestamp' => 200, 'hook' => 'recurring_hook', 'args' => ['a' => 1]],
         ['timestamp' => 300, 'hook' => 'recurring_hook', 'args' => ['a' => 1]],
     ], $GLOBALS['test_unscheduled_events'], 'Apply must unschedule only later duplicate recurring events');
+
+    $GLOBALS['wpdb']->queries = [];
+    $GLOBALS['wpdb']->query_results = [10000, 10000, 23];
+    assert_same(20023, Job_Log::cleanup(7), 'Job log cleanup must report rows deleted across every batch');
+    assert_same(3, count($GLOBALS['wpdb']->queries), 'Job log cleanup must continue until a partial batch is deleted');
+    foreach ($GLOBALS['wpdb']->queries as $cleanup_query) {
+        assert_true(str_contains($cleanup_query, 'ORDER BY completed_at ASC'), 'Job log cleanup must delete the oldest rows first');
+        assert_true(str_contains($cleanup_query, 'LIMIT 10000'), 'Job log cleanup must bound each delete statement');
+    }
 
     echo "Regression tests passed.\n";
 }


### PR DESCRIPTION
## Summary

- delete expired job-log rows in bounded 10,000-row batches
- process oldest rows first through the `completed_at` index
- repair missing `completed_at` indexes on existing installations
- cover multi-batch cleanup behavior with a regression test

## Testing

- `php -l src/class-job-log.php`
- `php -l tests/regression.php`
- `composer test:regression`

For superdav42/tgc.church#216.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.115 plugin for [OpenCode](https://opencode.ai) v1.17.18


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Log cleanup now removes records in manageable batches, improving reliability for large datasets.
  * Cleanup reports the total number of deleted log entries.
  * Added indexing to support faster cleanup based on completion time.

* **Bug Fixes**
  * Prevents oversized, unbatched deletion operations during log cleanup.

* **Tests**
  * Added regression coverage for batched deletion behavior and query limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->