### PR TITLE
fix: prevent queue worker bootstrap crash loops

### DIFF
--- a/bin/worker.php
+++ b/bin/worker.php
@@ -28,6 +28,13 @@ if (file_exists($plugin_autoload)) {
     require_once $plugin_autoload;
 }
 
+// Discover WordPress before loading the site Composer autoloader. Bedrock's
+// autoloaded plugin files may exit when ABSPATH has not been defined yet.
+$wp_load = Bootstrap::discover_wp_load(__DIR__);
+if (!defined('ABSPATH')) {
+    define('ABSPATH', rtrim(dirname($wp_load), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR);
+}
+
 // 2. Walk up from plugin root to find site autoloader (Bedrock: has Dotenv, etc.)
 $site_autoload = null;
 $search = dirname(__DIR__);
@@ -56,7 +63,6 @@ use QueueWorker\Worker_Process;
 // --- Discover WordPress and load environment ---
 $site_root = $site_autoload ? dirname($site_autoload, 2) : dirname(__DIR__);
 Bootstrap::load_dotenv($site_root);
-$wp_load = Bootstrap::discover_wp_load(__DIR__);
 
 // --- Configuration ---
 $socket_path    = Config::socket_path();

--- a/src/class-cli-commands.php
+++ b/src/class-cli-commands.php
@@ -30,6 +30,12 @@ class CLI_Commands
         }
 
         WP_CLI::success('Queue worker is running.');
+        if (array_key_exists('ready', $data) && !$data['ready']) {
+            WP_CLI::warning(sprintf(
+                'Queue worker is unavailable: %s. Resolve the error and restart the worker.',
+                $data['failure_reason'] ?? 'unknown error'
+            ));
+        }
         WP_CLI::log(sprintf('  PID:            %d', $data['pid'] ?? 0));
         WP_CLI::log(sprintf('  Uptime:         %s', $data['uptime'] ?? 'unknown'));
         WP_CLI::log(sprintf('  Pending timers: %d', $data['pending_timers'] ?? 0));

--- a/src/class-worker-process.php
+++ b/src/class-worker-process.php
@@ -64,6 +64,8 @@ class Worker_Process
     private int $last_rescan_started = 0;
     private int $last_rescan_finished = 0;
     private int $last_rescan_duration = 0;
+    private bool $is_ready = false;
+    private string $failure_reason = '';
 
     public function __construct(string $wp_load, string $primary_domain, string $execute_script, string $scan_script = '')
     {
@@ -103,7 +105,13 @@ class Worker_Process
             chmod($socket_path, 0660);
         }
 
-        $this->bootstrap_wordpress();
+        try {
+            $this->bootstrap_wordpress();
+        } catch (\Throwable $e) {
+            $this->mark_unready($worker_id, 'startup', $e);
+            return;
+        }
+
         Worker::log(sprintf('[W%d] WordPress bootstrapped for scanning. Primary domain: %s', $worker_id, $this->primary_domain));
 
         self::ensure_lock_table();
@@ -159,6 +167,7 @@ class Worker_Process
         Timer::add(30, function () use ($worker_id) {
             $this->check_limits($worker_id);
         });
+        $this->is_ready = true;
     }
 
     /**
@@ -171,6 +180,12 @@ class Worker_Process
         $decoded = json_decode($data, true);
         if (is_array($decoded) && isset($decoded['command'])) {
             $this->handle_command($connection, $decoded);
+            return;
+        }
+
+        if (!$this->is_ready) {
+            Worker::log('[SOCKET] Dropping job because the worker is unavailable: ' . $this->failure_reason);
+            $connection->close();
             return;
         }
 
@@ -198,6 +213,22 @@ class Worker_Process
         $_SERVER['REQUEST_METHOD'] = 'GET';
 
         require_once $this->wp_load;
+    }
+
+    /**
+     * Leaves the worker available for status requests while preventing a failed
+     * startup from repeatedly crashing and respawning it.
+     */
+    private function mark_unready(int $worker_id, string $context, \Throwable $e): void
+    {
+        $this->is_ready = false;
+        $this->failure_reason = sprintf('%s failed: %s: %s', $context, get_class($e), $e->getMessage());
+
+        Worker::log(sprintf(
+            '[W%d][UNAVAILABLE] %s. Jobs are paused; resolve the error and restart the worker.',
+            $worker_id,
+            $this->failure_reason
+        ));
     }
 
     /**
@@ -1075,6 +1106,8 @@ class Worker_Process
                     'running_as_lanes' => $this->running_action_scheduler_counts(),
                     'pending_as_lanes' => $this->pending_action_scheduler_counts(),
                     'memory'          => sprintf('%.1f MB', $mem_mb),
+                    'ready'           => $this->is_ready,
+                    'failure_reason'  => $this->failure_reason,
                     'running_details' => $running_details,
                     'rescan'          => [
                         'in_progress' => $this->is_rescanning,

--- a/tests/regression.php
+++ b/tests/regression.php
@@ -62,6 +62,18 @@ namespace {
             self::$successes[] = $message;
         }
     }
+
+    class Test_Connection
+    {
+        public bool $closed = false;
+        public ?string $response = null;
+
+        public function close(?string $response = null): void
+        {
+            $this->closed = true;
+            $this->response = $response;
+        }
+    }
 }
 
 namespace {
@@ -319,6 +331,26 @@ namespace {
     $decoded = json_decode($payload->to_json(), true);
     assert_same('checkout', $decoded['group'], 'Action Scheduler group must be serialized');
     assert_true(str_contains($payload->tracking_key(), ':checkout:'), 'Action Scheduler group must be part of the tracking key');
+
+    $failed_bootstrap_file = tempnam(sys_get_temp_dir(), 'qw-bootstrap-failure-');
+    assert_true(false !== $failed_bootstrap_file, 'Bootstrap failure fixture must be created');
+    assert_true(
+        false !== file_put_contents($failed_bootstrap_file, "<?php throw new \\RuntimeException('intentional bootstrap failure');"),
+        'Bootstrap failure fixture must be writable'
+    );
+    $failed_start_worker = new Worker_Process($failed_bootstrap_file, 'example.test', __FILE__);
+    $failed_start_worker->on_worker_start(new \Workerman\Worker());
+    assert_same(false, private_property($failed_start_worker, 'is_ready'), 'A bootstrap failure must leave the child running but unavailable');
+    assert_true(private_property($failed_start_worker, 'failure_reason') !== '', 'A bootstrap failure must retain an actionable reason');
+    $failed_start_status_connection = new Test_Connection();
+    $failed_start_worker->on_message($failed_start_status_connection, json_encode(['command' => 'status']));
+    $failed_start_status = json_decode((string) $failed_start_status_connection->response, true);
+    assert_same(false, $failed_start_status['ready'] ?? null, 'An unavailable worker must report its readiness state');
+    assert_true(($failed_start_status['failure_reason'] ?? '') !== '', 'An unavailable worker status response must report its failure reason');
+    $failed_start_job_connection = new Test_Connection();
+    $failed_start_worker->on_message($failed_start_job_connection, $payload->to_json());
+    assert_true($failed_start_job_connection->closed, 'An unavailable worker must reject queued jobs without crashing');
+    assert_true(unlink($failed_bootstrap_file), 'Bootstrap failure fixture must be removed');
 
     putenv('QUEUE_WORKER_AS_LANES=' . json_encode([
         [


### PR DESCRIPTION
## Summary

- define `ABSPATH` before loading the Bedrock Composer autoloader so guarded plugin files cannot terminate the worker during service startup
- keep a worker process available for status requests when WordPress bootstrap fails, while rejecting queued jobs and reporting the failure reason
- cover the unavailable-worker path with the regression suite

## Verification

- `php -l bin/worker.php && php -l src/class-worker-process.php && php -l src/class-cli-commands.php && php -l tests/regression.php`
- `php tests/regression.php`
- `/home/dave/tgc.church/site/vendor/bin/phpcs --standard=/home/dave/tgc.church/site/phpcs.xml bin/worker.php src/class-worker-process.php src/class-cli-commands.php tests/regression.php`
- local `wp-queue-worker-dev.service` restart: two stable children and responsive Unix-socket status endpoint

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.192 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker startup reliability when loading WordPress and site dependencies.
  * Workers that fail during startup now remain running but are marked unavailable instead of accepting jobs.
  * Job connections are safely closed when a worker is unavailable.
  * Status output now reports readiness and includes the startup failure reason.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->