### PR TITLE
GH#46: reject jobs when worker is unavailable

### DIFF
--- a/src/class-socket-client.php
+++ b/src/class-socket-client.php
@@ -32,15 +32,37 @@ class Socket_Client
 
         $message = $payload->to_json() . "\n";
         $written = fwrite($socket, $message);
-        fclose($socket);
 
         if ($written !== strlen($message)) {
+            fclose($socket);
             self::log_notify_failure($payload, sprintf(
                 'write failed for %s: wrote %d of %d bytes',
                 $path,
                 $written === false ? 0 : $written,
                 strlen($message)
             ));
+            return false;
+        }
+
+        stream_set_timeout($socket, 1);
+        $response = fgets($socket);
+        $meta = stream_get_meta_data($socket);
+        fclose($socket);
+
+        if (!$response) {
+            self::log_notify_failure(
+                $payload,
+                !empty($meta['timed_out']) ? 'timeout waiting for worker response' : 'empty worker response'
+            );
+            return false;
+        }
+
+        $result = json_decode($response, true);
+        if (!is_array($result) || empty($result['accepted'])) {
+            self::log_notify_failure(
+                $payload,
+                'worker rejected job: ' . ($result['reason'] ?? 'malformed response')
+            );
             return false;
         }
 

--- a/src/class-worker-process.php
+++ b/src/class-worker-process.php
@@ -185,18 +185,24 @@ class Worker_Process
 
         if (!$this->is_ready) {
             Worker::log('[SOCKET] Dropping job because the worker is unavailable: ' . $this->failure_reason);
-            $connection->close();
+            $connection->close(json_encode([
+                'accepted' => false,
+                'reason'   => 'worker_unavailable',
+            ]) . "\n");
             return;
         }
 
         try {
             $payload = Job_Payload::from_json($data);
             $this->schedule_timer($payload);
+            $connection->close(json_encode(['accepted' => true]) . "\n");
         } catch (\Throwable $e) {
             Worker::log('[SOCKET] Invalid payload: ' . $e->getMessage());
+            $connection->close(json_encode([
+                'accepted' => false,
+                'reason'   => 'invalid_payload',
+            ]) . "\n");
         }
-
-        $connection->close();
     }
 
     // ------------------------------------------------------------------

--- a/tests/regression.php
+++ b/tests/regression.php
@@ -350,6 +350,9 @@ namespace {
     $failed_start_job_connection = new Test_Connection();
     $failed_start_worker->on_message($failed_start_job_connection, $payload->to_json());
     assert_true($failed_start_job_connection->closed, 'An unavailable worker must reject queued jobs without crashing');
+    $failed_start_job_response = json_decode((string) $failed_start_job_connection->response, true);
+    assert_same(false, $failed_start_job_response['accepted'] ?? null, 'An unavailable worker must explicitly reject queued jobs');
+    assert_same('worker_unavailable', $failed_start_job_response['reason'] ?? null, 'An unavailable worker rejection must identify its state');
     assert_true(unlink($failed_bootstrap_file), 'Bootstrap failure fixture must be removed');
 
     putenv('QUEUE_WORKER_AS_LANES=' . json_encode([


### PR DESCRIPTION
## Summary

Adds a socket acknowledgement protocol so unavailable workers explicitly reject queued jobs and callers do not count rejected jobs as sent.

## Files Changed

src/class-socket-client.php, src/class-worker-process.php, tests/regression.php

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — php -l src/class-worker-process.php; php -l src/class-socket-client.php; php -l tests/regression.php; php tests/regression.php

Resolves #46


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.194 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra spent 3m and 65,657 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when submitting queued jobs through worker sockets.
  - Added clear responses when workers are unavailable or payloads cannot be processed.
  - Requests now validate worker responses and report failures for timeouts, invalid data, or rejected jobs.
  - Successful submissions receive explicit confirmation.

- **Tests**
  - Expanded regression coverage for job rejection when a worker fails to start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->