### PR TITLE
fix: define ABSPATH before execute-job autoload

### DIFF
--- a/bin/execute-job.php
+++ b/bin/execute-job.php
@@ -47,6 +47,13 @@ if (file_exists($plugin_autoload)) {
     require_once $plugin_autoload;
 }
 
+// Discover WordPress before loading the site Composer autoloader. Bedrock's
+// autoloaded plugin files may exit when ABSPATH has not been defined yet.
+$wp_load = qw_discover_wp_load(__DIR__);
+if (!defined('ABSPATH')) {
+    define('ABSPATH', rtrim(dirname($wp_load), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR);
+}
+
 // 2. Walk up from plugin root to find site autoloader (Bedrock: has Dotenv, etc.)
 $site_autoload = null;
 $search = dirname(__DIR__);
@@ -70,10 +77,9 @@ use QueueWorker\Bootstrap;
 use QueueWorker\Job_Executor;
 use QueueWorker\Job_Log;
 
-// --- Discover WordPress and load environment ---
+// --- Load environment ---
 $site_root = $site_autoload ? dirname($site_autoload, 2) : dirname(__DIR__);
 Bootstrap::load_dotenv($site_root);
-$wp_load = Bootstrap::discover_wp_load(__DIR__);
 
 // --- Bootstrap WordPress with the target site's domain ---
 $domain = parse_url($payload['site_url'] ?? '', PHP_URL_HOST);
@@ -138,4 +144,32 @@ function qw_payload_matches_sovereign_registry(int $site_id, string $domain): bo
 
     $domains = array_map('strtolower', array_map('strval', $entry['domains'] ?? []));
     return in_array(strtolower($domain), $domains, true);
+}
+
+function qw_discover_wp_load(string $start_dir): string
+{
+    $dir = $start_dir;
+
+    for ($i = 0; $i < 12; $i++) {
+        $candidates = [
+            $dir . '/wp-load.php',
+            $dir . '/web/wp/wp-load.php',
+            $dir . '/web/wp-load.php',
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (file_exists($candidate)) {
+                return $candidate;
+            }
+        }
+
+        $parent = dirname($dir);
+        if ($parent === $dir) {
+            break;
+        }
+        $dir = $parent;
+    }
+
+    fwrite(STDERR, "Could not locate wp-load.php.\n");
+    exit(1);
 }


### PR DESCRIPTION
Summary: updates bin/execute-job.php to discover wp-load.php and define ABSPATH before loading the Bedrock/site Composer autoloader. This matches the worker.php bootstrap safety pattern and prevents autoloaded plugin files from exiting before the job executor runs. Verification: php -l bin/execute-job.php; composer test:regression. Production evidence: hotpatched current release after backup at /srv/www/tgc.church/shared/aidevops-backups/the-perfect-wp-cron-20260730-0550/execute-job.php; exact child executor for site 49 action 203820 returned ok, wrote wp_qw_job_log row 24840673, completed action 203820, and advanced es_AR from 200 to 300; next automatic worker action 203821 completed and advanced es_AR to 400.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job execution in Bedrock-based sites by ensuring WordPress is located and initialized before dependent site components load.
  * Added support for discovering WordPress across common directory layouts.
  * Added a safeguard to define the WordPress installation path when it is not already available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->