### PR TITLE
fix: remove wp-load discovery cap

### DIFF
--- a/bin/execute-job.php
+++ b/bin/execute-job.php
@@ -150,7 +150,7 @@ function qw_discover_wp_load(string $start_dir): string
 {
     $dir = $start_dir;
 
-    for ($i = 0; $i < 12; $i++) {
+    while (true) {
         $candidates = [
             $dir . '/wp-load.php',
             $dir . '/web/wp/wp-load.php',


### PR DESCRIPTION
## Summary

- remove the fixed 12-directory limit while discovering `wp-load.php`
- retain the filesystem-root termination guard

## Testing

- `php -l bin/execute-job.php`
- `php tests/regression.php`

Resolves #49

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.200 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 2m and 51,234 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job execution environment discovery by searching all the way to the filesystem root, supporting projects nested beyond 12 directory levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->