### PR TITLE
GH#52: preserve sovereign scan JSON output

### DIFF
--- a/bin/scan-cron.php
+++ b/bin/scan-cron.php
@@ -25,6 +25,12 @@ if (!is_array($payload)) {
     exit(1);
 }
 
+// WordPress and plugins can emit notices while bootstrapping. The parent
+// process consumes stdout as a JSON-only protocol, so keep every incidental
+// byte out of that stream until the payload is ready to write.
+$stdout_buffer_level = ob_get_level();
+ob_start();
+
 // --- Load QueueWorker classes ---
 $plugin_autoload = dirname(__DIR__) . '/vendor/autoload.php';
 if (file_exists($plugin_autoload)) {
@@ -131,7 +137,29 @@ if (function_exists('as_get_scheduled_actions') && qw_scan_action_scheduler_tabl
     }
 }
 
-echo json_encode($payloads);
+// A plugin can leave nested output buffers open. Discard every buffer opened
+// during this scan before writing the protocol response to real stdout.
+$incidental_output = '';
+while (ob_get_level() > $stdout_buffer_level) {
+    $incidental_output .= (string) ob_get_clean();
+}
+
+if ($incidental_output !== '') {
+    fwrite(STDERR, sprintf(
+        "Suppressed %d bytes of bootstrap output (sha256:%s).\n",
+        strlen($incidental_output),
+        substr(hash('sha256', $incidental_output), 0, 12)
+    ));
+}
+
+try {
+    $encoded_payloads = json_encode($payloads, JSON_THROW_ON_ERROR);
+} catch (\JsonException $e) {
+    fwrite(STDERR, sprintf("Could not encode scan payload: %s.\n", $e->getMessage()));
+    exit(1);
+}
+
+fwrite(STDOUT, $encoded_payloads);
 
 function qw_scan_action_scheduler_tables_exist(): bool
 {

--- a/src/class-worker-process.php
+++ b/src/class-worker-process.php
@@ -963,23 +963,71 @@ class Worker_Process
         $exit_code = proc_close($process);
 
         if ($exit_code !== 0) {
-            $message = trim((string) $stderr);
-            Worker::log(sprintf('[RESCAN][SOVEREIGN][FAIL] Site %d scan failed: %s', $site_id, $message));
+            Worker::log(sprintf(
+                '[RESCAN][SOVEREIGN][FAIL] Site %d scan exited with code %d (%s)',
+                $site_id,
+                $exit_code,
+                $this->sovereign_scan_diagnostic('stderr', (string) $stderr)
+            ));
             return;
         }
 
-        $payloads = json_decode((string) $stdout, true);
-        if (!is_array($payloads)) {
-            Worker::log(sprintf('[RESCAN][SOVEREIGN][FAIL] Site %d scan returned invalid JSON', $site_id));
+        if ($stdout === '') {
+            Worker::log(sprintf(
+                '[RESCAN][SOVEREIGN][FAIL] Site %d scan returned empty output (%s)',
+                $site_id,
+                $this->sovereign_scan_diagnostic('stderr', (string) $stderr)
+            ));
+            return;
+        }
+
+        try {
+            $payloads = json_decode($stdout, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            Worker::log(sprintf(
+                '[RESCAN][SOVEREIGN][FAIL] Site %d scan returned invalid JSON (%s; %s; %s)',
+                $site_id,
+                $e->getMessage(),
+                $this->sovereign_scan_diagnostic('stdout', $stdout),
+                $this->sovereign_scan_diagnostic('stderr', (string) $stderr)
+            ));
+            return;
+        }
+
+        if (!array_is_list($payloads)) {
+            Worker::log(sprintf(
+                '[RESCAN][SOVEREIGN][FAIL] Site %d scan returned an invalid payload shape (%s)',
+                $site_id,
+                $this->sovereign_scan_diagnostic('stdout', $stdout)
+            ));
             return;
         }
 
         foreach ($payloads as $payload_data) {
             if (!is_array($payload_data)) {
-                continue;
+                Worker::log(sprintf(
+                    '[RESCAN][SOVEREIGN][FAIL] Site %d scan returned an invalid payload shape (%s)',
+                    $site_id,
+                    $this->sovereign_scan_diagnostic('stdout', $stdout)
+                ));
+                return;
             }
+        }
+
+        foreach ($payloads as $payload_data) {
             $this->schedule_timer(new Job_Payload($payload_data));
         }
+    }
+
+    private function sovereign_scan_diagnostic(string $stream, string $output): string
+    {
+        return sprintf(
+            '%s_bytes=%d %s_sha256=%s',
+            $stream,
+            strlen($output),
+            $stream,
+            substr(hash('sha256', $output), 0, 12)
+        );
     }
 
     private function site_url_from_registry_entry(array $entry): string

--- a/tests/regression.php
+++ b/tests/regression.php
@@ -4,9 +4,11 @@ namespace Workerman {
     class Worker
     {
         public int $id = 0;
+        public static array $logs = [];
 
         public static function log(string $message): void
         {
+            self::$logs[] = $message;
         }
 
         public static function stopAll(): void
@@ -387,6 +389,89 @@ namespace {
         'source' => 'action_scheduler',
         'group' => 'checkout',
     ])]), 'AS lane must not match when hook differs');
+
+    $scan_fixture = tempnam(sys_get_temp_dir(), 'qw-sovereign-scan-');
+    assert_true(false !== $scan_fixture, 'Sovereign scan fixture must be created');
+    $sovereign_entry = ['domains' => ['tenant.example.test']];
+    $sovereign_worker = new Worker_Process(__FILE__, 'example.test', __FILE__, $scan_fixture);
+
+    assert_true(
+        false !== file_put_contents($scan_fixture, "<?php fwrite(STDOUT, \"bootstrap notice\\n[]\");"),
+        'Noisy sovereign scan fixture must be writable'
+    );
+    \Workerman\Worker::$logs = [];
+    invoke_private($sovereign_worker, 'rescan_sovereign_site_jobs', [7, $sovereign_entry]);
+    assert_true(
+        str_contains(implode("\n", \Workerman\Worker::$logs), 'returned invalid JSON'),
+        'Noisy subprocess stdout must be rejected instead of scheduling partial jobs'
+    );
+    assert_true(
+        str_contains(implode("\n", \Workerman\Worker::$logs), 'stdout_bytes='),
+        'Invalid subprocess JSON diagnostics must be bounded to metadata'
+    );
+
+    assert_true(
+        false !== file_put_contents($scan_fixture, '<?php fwrite(STDERR, "sensitive bootstrap detail"); exit(7);'),
+        'Failed sovereign scan fixture must be writable'
+    );
+    \Workerman\Worker::$logs = [];
+    invoke_private($sovereign_worker, 'rescan_sovereign_site_jobs', [7, $sovereign_entry]);
+    assert_true(
+        str_contains(implode("\n", \Workerman\Worker::$logs), 'exited with code 7'),
+        'Failed subprocesses must report their exit status'
+    );
+    assert_true(
+        !str_contains(implode("\n", \Workerman\Worker::$logs), 'sensitive bootstrap detail'),
+        'Failed subprocess diagnostics must not expose stderr contents'
+    );
+
+    assert_true(
+        false !== file_put_contents($scan_fixture, '<?php'),
+        'Empty-output sovereign scan fixture must be writable'
+    );
+    \Workerman\Worker::$logs = [];
+    invoke_private($sovereign_worker, 'rescan_sovereign_site_jobs', [7, $sovereign_entry]);
+    assert_true(
+        str_contains(implode("\n", \Workerman\Worker::$logs), 'returned empty output'),
+        'Empty subprocess output must be distinguishable from invalid JSON'
+    );
+
+    assert_true(
+        false !== file_put_contents($scan_fixture, '<?php fwrite(STDOUT, "[null]");'),
+        'Invalid-shape sovereign scan fixture must be writable'
+    );
+    \Workerman\Worker::$logs = [];
+    invoke_private($sovereign_worker, 'rescan_sovereign_site_jobs', [7, $sovereign_entry]);
+    assert_true(
+        str_contains(implode("\n", \Workerman\Worker::$logs), 'invalid payload shape'),
+        'Malformed payload arrays must not schedule partial jobs'
+    );
+
+    assert_true(
+        false !== file_put_contents($scan_fixture, '<?php fwrite(STDOUT, "[]");'),
+        'Empty-list sovereign scan fixture must be writable'
+    );
+    \Workerman\Worker::$logs = [];
+    invoke_private($sovereign_worker, 'rescan_sovereign_site_jobs', [7, $sovereign_entry]);
+    assert_same([], \Workerman\Worker::$logs, 'A valid empty sovereign scan must not be reported as a failure');
+
+    assert_true(
+        false !== file_put_contents($scan_fixture, '<?php fwrite(STDOUT, "[{\"site_id\":7,\"site_url\":\"https://tenant.example.test\",\"hook\":\"sovereign_hook\",\"args\":[],\"timestamp\":2147483647,\"source\":\"wp_cron\"}]");'),
+        'Valid sovereign scan fixture must be writable'
+    );
+    \Workerman\Timer::$delays = [];
+    \Workerman\Worker::$logs = [];
+    invoke_private($sovereign_worker, 'rescan_sovereign_site_jobs', [7, $sovereign_entry]);
+    assert_same(1, count(\Workerman\Timer::$delays), 'Valid sovereign payload arrays must continue to schedule normally');
+    assert_same([], \Workerman\Worker::$logs, 'Valid sovereign payload arrays must not be reported as failures');
+
+    $scan_script = file_get_contents(__DIR__ . '/../bin/scan-cron.php');
+    assert_true(is_string($scan_script), 'Sovereign scan script must be readable');
+    assert_true(
+        str_contains($scan_script, '$stdout_buffer_level = ob_get_level();') && str_contains($scan_script, 'JSON_THROW_ON_ERROR'),
+        'Sovereign scan script must isolate bootstrap output and fail safely when encoding JSON'
+    );
+    assert_true(unlink($scan_fixture), 'Sovereign scan fixture must be removed');
 
     \Workerman\Timer::$delays = [];
     $registry_content_dir = sys_get_temp_dir() . '/qw-regression-content-' . getmypid();


### PR DESCRIPTION
Resolves #52; Buffered incidental WordPress bootstrap output so the sovereign scan protocol emits exactly one JSON document. The worker now classifies exit, empty-output, malformed-JSON, and malformed-payload failures using bounded hashes and schedules only validated lists. Verified with PHP syntax checks and composer test:regression. <!-- aidevops:sig --> --- [aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 4m and 100,365 tokens on this as a headless worker.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 7m and 111,880 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scan reliability when startup processes produce unexpected output.
  - Scans now clearly report failures caused by nonzero exits, empty responses, malformed JSON, or invalid result data.
  - Prevented valid empty scan results from being incorrectly treated as failures.
  - Added clearer diagnostic details for troubleshooting failed scans.
  - Improved error handling when scan results cannot be encoded or processed safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->