### PR TITLE
fix: schedule cron for isolated networks

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
-      - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build

--- a/bin/execute-job.php
+++ b/bin/execute-job.php
@@ -76,6 +76,7 @@ if (!class_exists('QueueWorker\\Config')) {
 use QueueWorker\Bootstrap;
 use QueueWorker\Job_Executor;
 use QueueWorker\Job_Log;
+use QueueWorker\Job_Payload;
 
 // --- Load environment ---
 $site_root = $site_autoload ? dirname($site_autoload, 2) : dirname(__DIR__);
@@ -106,15 +107,55 @@ require_once $wp_load;
 // WordPress loads is unsafe because site-active plugins and database routing
 // have already been selected for the wrong site.
 $site_id = (int) ($payload['site_id'] ?? get_current_blog_id());
-$is_sovereign_tenant = (defined('WU_MT_SOVEREIGN_TENANT') && (int) WU_MT_SOVEREIGN_TENANT === $site_id)
-    || qw_payload_matches_sovereign_registry($site_id, $domain);
-if (!$is_sovereign_tenant && $site_id !== get_current_blog_id()) {
-    fwrite(STDERR, sprintf(
-        "Payload site mismatch: URL resolved to blog %d, expected blog %d.\n",
-        get_current_blog_id(),
-        $site_id
-    ));
-    exit(1);
+$isolated_network_id = (int) ($payload['isolated_network_id'] ?? 0);
+$local_site_id = (int) ($payload['local_site_id'] ?? 0);
+
+foreach ($payloads as $batch_payload) {
+    if (!is_array($batch_payload) || (int) ($batch_payload['site_id'] ?? 0) !== $site_id) {
+        fwrite(STDERR, "Batch contains mismatched queue site identities.\n");
+        exit(1);
+    }
+}
+
+if ($isolated_network_id > 0 || $local_site_id > 0) {
+    try {
+        foreach ($payloads as $batch_payload) {
+            $job_payload = new Job_Payload($batch_payload);
+            if (!$job_payload->routes_to_isolated_network($isolated_network_id)
+                || $job_payload->local_site_id !== $local_site_id
+            ) {
+                throw new \RuntimeException('batch routing metadata mismatch');
+            }
+        }
+    } catch (\Throwable $e) {
+        fwrite(STDERR, "Invalid isolated network payload: " . $e->getMessage() . "\n");
+        exit(1);
+    }
+
+    if (!defined('WU_MT_LEGACY_ISOLATED_NETWORK')
+        || (int) WU_MT_LEGACY_ISOLATED_NETWORK !== $isolated_network_id
+        || get_current_blog_id() !== $local_site_id
+    ) {
+        fwrite(STDERR, sprintf(
+            "Isolated payload route mismatch: resolved network %d blog %d, expected network %d blog %d.\n",
+            defined('WU_MT_LEGACY_ISOLATED_NETWORK') ? (int) WU_MT_LEGACY_ISOLATED_NETWORK : 0,
+            get_current_blog_id(),
+            $isolated_network_id,
+            $local_site_id
+        ));
+        exit(1);
+    }
+} else {
+    $is_sovereign_tenant = (defined('WU_MT_SOVEREIGN_TENANT') && (int) WU_MT_SOVEREIGN_TENANT === $site_id)
+        || qw_payload_matches_sovereign_registry($site_id, $domain);
+    if (!$is_sovereign_tenant && $site_id !== get_current_blog_id()) {
+        fwrite(STDERR, sprintf(
+            "Payload site mismatch: URL resolved to blog %d, expected blog %d.\n",
+            get_current_blog_id(),
+            $site_id
+        ));
+        exit(1);
+    }
 }
 
 Job_Log::ensure_table();

--- a/bin/scan-cron.php
+++ b/bin/scan-cron.php
@@ -81,60 +81,48 @@ define('QUEUE_WORKER_RUNNING', true);
 
 require_once $wp_load;
 
-$site_id = (int) ($payload['site_id'] ?? get_current_blog_id());
-$is_sovereign_tenant = (defined('WU_MT_SOVEREIGN_TENANT') && (int) WU_MT_SOVEREIGN_TENANT === $site_id)
-    || qw_scan_payload_matches_sovereign_registry($site_id, $domain);
-if (!$is_sovereign_tenant && $site_id !== get_current_blog_id()) {
-    switch_to_blog($site_id);
-}
-
-wp_cache_delete('cron', 'options');
-wp_cache_delete('alloptions', 'options');
-
 $payloads = [];
-$crons = _get_cron_array();
-if (is_array($crons)) {
-    $seen_cron_signatures = [];
-    foreach ($crons as $timestamp => $hooks) {
-        if (!is_array($hooks)) {
-            continue;
-        }
-        foreach ($hooks as $hook => $events) {
-            if (Cron_Event_Filter::should_bypass($hook)) {
-                continue;
-            }
-            foreach ($events as $event) {
-                $signature = qw_scan_cron_event_signature($hook, $event, (int) $timestamp);
-                if (isset($seen_cron_signatures[$signature])) {
-                    continue;
-                }
-                $seen_cron_signatures[$signature] = true;
+$isolated_network_id = (int) ($payload['isolated_network_id'] ?? 0);
+if ($isolated_network_id > 0) {
+    if (!defined('WU_MT_LEGACY_ISOLATED_NETWORK')
+        || (int) WU_MT_LEGACY_ISOLATED_NETWORK !== $isolated_network_id
+    ) {
+        fwrite(STDERR, sprintf(
+            "Isolated network mismatch: domain routed to network %d, expected network %d.\n",
+            defined('WU_MT_LEGACY_ISOLATED_NETWORK') ? (int) WU_MT_LEGACY_ISOLATED_NETWORK : 0,
+            $isolated_network_id
+        ));
+        exit(1);
+    }
 
-                $event_obj = (object) array_merge($event, [
-                    'hook'      => $hook,
-                    'timestamp' => $timestamp,
-                ]);
-                $payloads[] = json_decode(Job_Payload::from_cron_event($event_obj)->to_json(), true);
-            }
+    $initial_blog_id = get_current_blog_id();
+    $site_ids = is_multisite() ? get_sites(['number' => 0, 'fields' => 'ids']) : [$initial_blog_id];
+    foreach ($site_ids as $local_site_id) {
+        $local_site_id = (int) $local_site_id;
+        $switched = $local_site_id !== get_current_blog_id();
+        if ($switched) {
+            switch_to_blog($local_site_id);
+        }
+
+        $payloads = array_merge($payloads, qw_scan_current_site_jobs());
+
+        if ($switched) {
+            restore_current_blog();
         }
     }
-}
 
-if (function_exists('as_get_scheduled_actions') && qw_scan_action_scheduler_tables_exist()) {
-    try {
-        $actions = as_get_scheduled_actions([
-            'status'   => \ActionScheduler_Store::STATUS_PENDING,
-            'per_page' => 500,
-        ]);
-        foreach ($actions as $action_id => $action) {
-            $action_payload = Job_Payload::from_as_action($action_id);
-            if ($action_payload) {
-                $payloads[] = json_decode($action_payload->to_json(), true);
-            }
-        }
-    } catch (\Throwable $e) {
-        fwrite(STDERR, "Action Scheduler scan failed: " . $e->getMessage() . "\n");
+    if ($initial_blog_id !== get_current_blog_id()) {
+        switch_to_blog($initial_blog_id);
     }
+} else {
+    $site_id = (int) ($payload['site_id'] ?? get_current_blog_id());
+    $is_sovereign_tenant = (defined('WU_MT_SOVEREIGN_TENANT') && (int) WU_MT_SOVEREIGN_TENANT === $site_id)
+        || qw_scan_payload_matches_sovereign_registry($site_id, $domain);
+    if (!$is_sovereign_tenant && $site_id !== get_current_blog_id()) {
+        switch_to_blog($site_id);
+    }
+
+    $payloads = qw_scan_current_site_jobs();
 }
 
 // A plugin can leave nested output buffers open. Discard every buffer opened
@@ -160,6 +148,60 @@ try {
 }
 
 fwrite(STDOUT, $encoded_payloads);
+
+function qw_scan_current_site_jobs(): array
+{
+    wp_cache_delete('cron', 'options');
+    wp_cache_delete('alloptions', 'options');
+
+    $payloads = [];
+    $crons = _get_cron_array();
+    if (is_array($crons)) {
+        $seen_cron_signatures = [];
+        foreach ($crons as $timestamp => $hooks) {
+            if (!is_array($hooks)) {
+                continue;
+            }
+            foreach ($hooks as $hook => $events) {
+                if (Cron_Event_Filter::should_bypass($hook)) {
+                    continue;
+                }
+                foreach ($events as $event) {
+                    $signature = qw_scan_cron_event_signature($hook, $event, (int) $timestamp);
+                    if (isset($seen_cron_signatures[$signature])) {
+                        continue;
+                    }
+                    $seen_cron_signatures[$signature] = true;
+
+                    $event_obj = (object) array_merge($event, [
+                        'hook'      => $hook,
+                        'timestamp' => $timestamp,
+                    ]);
+                    $payloads[] = json_decode(Job_Payload::from_cron_event($event_obj)->to_json(), true);
+                }
+            }
+        }
+    }
+
+    if (function_exists('as_get_scheduled_actions') && qw_scan_action_scheduler_tables_exist()) {
+        try {
+            $actions = as_get_scheduled_actions([
+                'status'   => \ActionScheduler_Store::STATUS_PENDING,
+                'per_page' => 500,
+            ]);
+            foreach ($actions as $action_id => $action) {
+                $action_payload = Job_Payload::from_as_action($action_id);
+                if ($action_payload) {
+                    $payloads[] = json_decode($action_payload->to_json(), true);
+                }
+            }
+        } catch (\Throwable $e) {
+            fwrite(STDERR, "Action Scheduler scan failed: " . $e->getMessage() . "\n");
+        }
+    }
+
+    return $payloads;
+}
 
 function qw_scan_action_scheduler_tables_exist(): bool
 {

--- a/src/class-job-payload.php
+++ b/src/class-job-payload.php
@@ -4,7 +4,11 @@ namespace QueueWorker;
 
 class Job_Payload
 {
+    private const ISOLATED_SITE_FACTOR = 4294967296;
+
     public int $site_id;
+    public int $isolated_network_id;
+    public int $local_site_id;
     public string $site_url;
     public string $hook;
     public array $args;
@@ -18,7 +22,9 @@ class Job_Payload
 
     public function __construct(array $data = [])
     {
-        $this->site_id   = $data['site_id'] ?? self::current_site_id();
+        $this->isolated_network_id = (int) ($data['isolated_network_id'] ?? self::current_isolated_network_id());
+        $this->local_site_id = (int) ($data['local_site_id'] ?? ($this->isolated_network_id > 0 ? get_current_blog_id() : 0));
+        $this->site_id   = (int) ($data['site_id'] ?? self::current_site_id());
         $this->site_url  = $data['site_url'] ?? self::current_site_url();
         $this->hook      = $data['hook'] ?? '';
         $this->args      = $data['args'] ?? [];
@@ -29,22 +35,34 @@ class Job_Payload
         $this->action_id = $data['action_id'] ?? 0;
         $this->group     = $data['group'] ?? '';
         $this->lane      = $data['lane'] ?? ($this->source === 'action_scheduler' ? 'action_scheduler' : 'wp_cron');
+
+        if (($this->isolated_network_id > 0) !== ($this->local_site_id > 0)) {
+            throw new \InvalidArgumentException('Incomplete isolated network routing metadata');
+        }
+
+        if ($this->isolated_network_id > 0
+            && $this->site_id !== self::isolated_site_id($this->isolated_network_id, $this->local_site_id)
+        ) {
+            throw new \InvalidArgumentException('Isolated queue site identity does not match its routing metadata');
+        }
     }
 
     public function to_json(): string
     {
         return json_encode([
-            'site_id'   => $this->site_id,
-            'site_url'  => $this->site_url,
-            'hook'      => $this->hook,
-            'args'      => $this->args,
-            'timestamp' => $this->timestamp,
-            'schedule'  => $this->schedule,
-            'interval'  => $this->interval,
-            'source'    => $this->source,
-            'action_id' => $this->action_id,
-            'group'     => $this->group,
-            'lane'      => $this->lane,
+            'site_id'             => $this->site_id,
+            'isolated_network_id' => $this->isolated_network_id,
+            'local_site_id'       => $this->local_site_id,
+            'site_url'            => $this->site_url,
+            'hook'                => $this->hook,
+            'args'                => $this->args,
+            'timestamp'           => $this->timestamp,
+            'schedule'            => $this->schedule,
+            'interval'            => $this->interval,
+            'source'              => $this->source,
+            'action_id'           => $this->action_id,
+            'group'               => $this->group,
+            'lane'                => $this->lane,
         ]);
     }
 
@@ -151,10 +169,35 @@ class Job_Payload
         return $this->is_recurring() ? 'wp_cron:recurring' : 'wp_cron:one-shot';
     }
 
+    public static function isolated_site_id(int $network_id, int $local_site_id): int
+    {
+        if (PHP_INT_SIZE < 8 || $network_id < 1 || $network_id > 2147483647
+            || $local_site_id < 1 || $local_site_id > 4294967295
+        ) {
+            throw new \InvalidArgumentException('Isolated network and local site IDs exceed the queue identity range');
+        }
+
+        return ($network_id * self::ISOLATED_SITE_FACTOR) + $local_site_id;
+    }
+
+    public function routes_to_isolated_network(int $network_id): bool
+    {
+        if ($network_id < 1 || $this->isolated_network_id !== $network_id || $this->local_site_id < 1) {
+            return false;
+        }
+
+        return $this->site_id === self::isolated_site_id($network_id, $this->local_site_id);
+    }
+
     private static function current_site_id(): int
     {
         if (defined('WU_MT_SOVEREIGN_TENANT')) {
             return (int) WU_MT_SOVEREIGN_TENANT;
+        }
+
+        $isolated_network_id = self::current_isolated_network_id();
+        if ($isolated_network_id > 0) {
+            return self::isolated_site_id($isolated_network_id, get_current_blog_id());
         }
 
         if (function_exists('ms_is_switched') && ms_is_switched()) {
@@ -173,6 +216,15 @@ class Job_Payload
         }
 
         return get_current_blog_id();
+    }
+
+    private static function current_isolated_network_id(): int
+    {
+        if (defined('WU_MT_SOVEREIGN_TENANT') || !defined('WU_MT_LEGACY_ISOLATED_NETWORK')) {
+            return 0;
+        }
+
+        return (int) WU_MT_LEGACY_ISOLATED_NETWORK;
     }
 
     /**

--- a/src/class-socket-client.php
+++ b/src/class-socket-client.php
@@ -115,4 +115,19 @@ class Socket_Client
     {
         return file_exists(self::get_socket_path());
     }
+
+    /**
+     * Let Ultimate Multisite distinguish an intentional DISABLE_WP_CRON from
+     * a site that has no working external cron runner.
+     */
+    public static function filter_wp_cron_status_override($status)
+    {
+        if ($status !== null || !self::is_worker_running()) {
+            return $status;
+        }
+
+        $worker_status = self::send_command('status', 1);
+
+        return is_array($worker_status) && !empty($worker_status['ready']) ? true : null;
+    }
 }

--- a/src/class-worker-process.php
+++ b/src/class-worker-process.php
@@ -858,12 +858,19 @@ class Worker_Process
     {
         $sites = get_sites(['number' => 0, 'fields' => 'ids']);
         $sovereign_sites = $this->sovereign_site_entries();
+        $isolated_networks = $this->isolated_network_entries();
 
         $current_blog_id = get_current_blog_id();
 
         foreach ($sites as $site_id) {
             $site_id = (int) $site_id;
             if (isset($sovereign_sites[$site_id])) {
+                continue;
+            }
+
+            $site = get_site($site_id);
+            $network_id = $site ? (int) $site->site_id : 0;
+            if (isset($isolated_networks[$network_id])) {
                 continue;
             }
 
@@ -914,6 +921,10 @@ class Worker_Process
 
         foreach ($sovereign_sites as $site_id => $entry) {
             $this->rescan_sovereign_site_jobs((int) $site_id, $entry);
+        }
+
+        foreach ($isolated_networks as $network_id => $entry) {
+            $this->rescan_isolated_network_jobs((int) $network_id, $entry);
         }
 
         if ($current_blog_id !== get_current_blog_id()) {
@@ -993,16 +1004,80 @@ class Worker_Process
         return $entries;
     }
 
+    /**
+     * Load routable isolated networks from the generated network registry.
+     *
+     * The registry is read on every full rescan so newly provisioned tenant
+     * databases are picked up without restarting the worker.
+     *
+     * @return array<int, array>
+     */
+    private function isolated_network_entries(): array
+    {
+        if (!defined('WP_CONTENT_DIR')) {
+            return [];
+        }
+
+        $path = WP_CONTENT_DIR . '/network-registry.data.json';
+        if (!is_readable($path)) {
+            return [];
+        }
+
+        $json = file_get_contents($path);
+        $data = json_decode($json ?: '', true);
+        if (!is_array($data) || empty($data['networks']) || !is_array($data['networks'])) {
+            return [];
+        }
+
+        $entries = [];
+        foreach ($data['networks'] as $registry_id => $entry) {
+            if (!is_array($entry) || ($entry['tier'] ?? '') !== 'isolated') {
+                continue;
+            }
+            if (($entry['status'] ?? 'active') !== 'active') {
+                continue;
+            }
+
+            $network_id = (int) ($entry['network_id'] ?? $entry['id'] ?? $registry_id);
+            if ($network_id < 1 || $this->site_url_from_registry_entry($entry) === '') {
+                continue;
+            }
+
+            $entries[$network_id] = $entry;
+        }
+
+        return $entries;
+    }
+
     private function rescan_sovereign_site_jobs(int $site_id, array $entry): void
     {
+        $this->rescan_registry_jobs('SOVEREIGN', 'site', $site_id, $entry, [
+            'site_id' => $site_id,
+        ]);
+    }
+
+    private function rescan_isolated_network_jobs(int $network_id, array $entry): void
+    {
+        $this->rescan_registry_jobs('ISOLATED', 'network', $network_id, $entry, [
+            'isolated_network_id' => $network_id,
+        ]);
+    }
+
+    private function rescan_registry_jobs(
+        string $registry_kind,
+        string $subject,
+        int $registry_id,
+        array $entry,
+        array $routing
+    ): void {
         if ($this->scan_script === '' || !file_exists($this->scan_script)) {
-            Worker::log(sprintf('[RESCAN][SOVEREIGN][ERROR] Missing scan script for site %d', $site_id));
+            Worker::log(sprintf('[RESCAN][%s][ERROR] Missing scan script for %s %d', $registry_kind, $subject, $registry_id));
             return;
         }
 
         $site_url = $this->site_url_from_registry_entry($entry);
         if ($site_url === '') {
-            Worker::log(sprintf('[RESCAN][SOVEREIGN][ERROR] Missing tenant domain for site %d', $site_id));
+            Worker::log(sprintf('[RESCAN][%s][ERROR] Missing tenant domain for %s %d', $registry_kind, $subject, $registry_id));
             return;
         }
 
@@ -1014,14 +1089,13 @@ class Worker_Process
         ], $pipes);
 
         if (!is_resource($process)) {
-            Worker::log(sprintf('[RESCAN][SOVEREIGN][ERROR] Failed to spawn scan for site %d', $site_id));
+            Worker::log(sprintf('[RESCAN][%s][ERROR] Failed to spawn scan for %s %d', $registry_kind, $subject, $registry_id));
             return;
         }
 
-        fwrite($pipes[0], json_encode([
-            'site_id'  => $site_id,
+        fwrite($pipes[0], json_encode(array_merge($routing, [
             'site_url' => $site_url,
-        ]));
+        ])));
         fclose($pipes[0]);
 
         $stdout = stream_get_contents($pipes[1]);
@@ -1032,8 +1106,10 @@ class Worker_Process
 
         if ($exit_code !== 0) {
             Worker::log(sprintf(
-                '[RESCAN][SOVEREIGN][FAIL] Site %d scan exited with code %d (%s)',
-                $site_id,
+                '[RESCAN][%s][FAIL] %s %d scan exited with code %d (%s)',
+                $registry_kind,
+                ucfirst($subject),
+                $registry_id,
                 $exit_code,
                 $this->sovereign_scan_diagnostic('stderr', (string) $stderr)
             ));
@@ -1042,8 +1118,10 @@ class Worker_Process
 
         if ($stdout === '') {
             Worker::log(sprintf(
-                '[RESCAN][SOVEREIGN][FAIL] Site %d scan returned empty output (%s)',
-                $site_id,
+                '[RESCAN][%s][FAIL] %s %d scan returned empty output (%s)',
+                $registry_kind,
+                ucfirst($subject),
+                $registry_id,
                 $this->sovereign_scan_diagnostic('stderr', (string) $stderr)
             ));
             return;
@@ -1053,8 +1131,10 @@ class Worker_Process
             $payloads = json_decode($stdout, true, 512, JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
             Worker::log(sprintf(
-                '[RESCAN][SOVEREIGN][FAIL] Site %d scan returned invalid JSON (%s; %s; %s)',
-                $site_id,
+                '[RESCAN][%s][FAIL] %s %d scan returned invalid JSON (%s; %s; %s)',
+                $registry_kind,
+                ucfirst($subject),
+                $registry_id,
                 $e->getMessage(),
                 $this->sovereign_scan_diagnostic('stdout', $stdout),
                 $this->sovereign_scan_diagnostic('stderr', (string) $stderr)
@@ -1064,26 +1144,54 @@ class Worker_Process
 
         if (!array_is_list($payloads)) {
             Worker::log(sprintf(
-                '[RESCAN][SOVEREIGN][FAIL] Site %d scan returned an invalid payload shape (%s)',
-                $site_id,
+                '[RESCAN][%s][FAIL] %s %d scan returned an invalid payload shape (%s)',
+                $registry_kind,
+                ucfirst($subject),
+                $registry_id,
                 $this->sovereign_scan_diagnostic('stdout', $stdout)
             ));
             return;
         }
 
+        $validated_payloads = [];
         foreach ($payloads as $payload_data) {
             if (!is_array($payload_data)) {
                 Worker::log(sprintf(
-                    '[RESCAN][SOVEREIGN][FAIL] Site %d scan returned an invalid payload shape (%s)',
-                    $site_id,
+                    '[RESCAN][%s][FAIL] %s %d scan returned an invalid payload shape (%s)',
+                    $registry_kind,
+                    ucfirst($subject),
+                    $registry_id,
                     $this->sovereign_scan_diagnostic('stdout', $stdout)
                 ));
                 return;
             }
+
+            try {
+                $payload = new Job_Payload($payload_data);
+            } catch (\Throwable $e) {
+                Worker::log(sprintf(
+                    '[RESCAN][%s][FAIL] %s %d scan returned invalid routing metadata (%s)',
+                    $registry_kind,
+                    ucfirst($subject),
+                    $registry_id,
+                    $e->getMessage()
+                ));
+                return;
+            }
+
+            if ($registry_kind === 'ISOLATED' && !$payload->routes_to_isolated_network($registry_id)) {
+                Worker::log(sprintf(
+                    '[RESCAN][ISOLATED][FAIL] Network %d scan did not route to the expected isolated network',
+                    $registry_id
+                ));
+                return;
+            }
+
+            $validated_payloads[] = $payload;
         }
 
-        foreach ($payloads as $payload_data) {
-            $this->schedule_timer(new Job_Payload($payload_data));
+        foreach ($validated_payloads as $payload) {
+            $this->schedule_timer($payload);
         }
     }
 
@@ -1100,7 +1208,15 @@ class Worker_Process
 
     private function site_url_from_registry_entry(array $entry): string
     {
-        foreach ($entry['domains'] ?? [] as $domain) {
+        $domains = $entry['domains'] ?? [];
+        if (!is_array($domains)) {
+            $domains = [];
+        }
+        if (!empty($entry['domain'])) {
+            array_unshift($domains, $entry['domain']);
+        }
+
+        foreach ($domains as $domain) {
             $domain = trim((string) $domain);
             if ($domain !== '') {
                 return 'https://' . $domain . '/';

--- a/tests/regression.php
+++ b/tests/regression.php
@@ -106,12 +106,15 @@ namespace {
     use QueueWorker\Cron_Interceptor;
     use QueueWorker\Job_Log;
     use QueueWorker\Job_Payload;
+    use QueueWorker\Socket_Client;
     use QueueWorker\Worker_Process;
 
     $_SERVER['HTTP_HOST'] = 'example.test';
 
     $GLOBALS['test_crons'] = [];
     $GLOBALS['test_current_blog_id'] = 1;
+    $GLOBALS['test_sites'] = [1];
+    $GLOBALS['test_site_network_ids'] = [];
     $GLOBALS['test_filters'] = [];
     $GLOBALS['test_actions'] = [];
     $GLOBALS['test_switched_blogs'] = [];
@@ -159,6 +162,10 @@ namespace {
         strpos($plugin_entrypoint, "add_action('init', ['QueueWorker\\\\Cron_Interceptor', 'register'])")
             < strpos($plugin_entrypoint, 'if ($job_executor_running)'),
         'Executor subprocesses must register scheduling interceptors before stopping normal plugin bootstrap'
+    );
+    assert_true(
+        str_contains($plugin_entrypoint, "add_filter('wu_wp_cron_status_override', ['QueueWorker\\\\Socket_Client', 'filter_wp_cron_status_override'])"),
+        'Plugin bootstrap must register the Ultimate Multisite cron health override'
     );
 
     class Test_WPDB
@@ -246,11 +253,10 @@ namespace {
 
     function get_site(int $site_id): object
     {
-        unset($site_id);
-
         return (object) [
-            'domain' => $GLOBALS['test_site_domain'],
-            'path'   => $GLOBALS['test_site_path'],
+            'domain'  => $GLOBALS['test_site_domain'],
+            'path'    => $GLOBALS['test_site_path'],
+            'site_id' => $GLOBALS['test_site_network_ids'][$site_id] ?? 1,
         ];
     }
 
@@ -276,7 +282,9 @@ namespace {
 
     function get_sites(array $args): array
     {
-        return [1];
+        unset($args);
+
+        return $GLOBALS['test_sites'];
     }
 
     function switch_to_blog(int $site_id): void
@@ -429,6 +437,7 @@ namespace {
     require_once __DIR__ . '/../src/class-job-log.php';
     require_once __DIR__ . '/../src/class-job-payload.php';
     require_once __DIR__ . '/../src/class-job-executor.php';
+    require_once __DIR__ . '/../src/class-socket-client.php';
     require_once __DIR__ . '/../src/class-worker-process.php';
 
     $payload = new Job_Payload([
@@ -687,6 +696,135 @@ namespace {
             'example.test' => 7,
         ],
     ])), 'Registry fixture must be writable');
+
+    $isolated_site_1 = Job_Payload::isolated_site_id(49, 1);
+    $isolated_site_2 = Job_Payload::isolated_site_id(49, 2);
+    $other_network_site_1 = Job_Payload::isolated_site_id(50, 1);
+    assert_same(210453397505, $isolated_site_1, 'Isolated queue identity must combine the network and local blog IDs deterministically');
+    assert_true($isolated_site_1 !== $isolated_site_2, 'Local blog IDs must not collide inside one isolated network');
+    assert_true($isolated_site_1 !== $other_network_site_1, 'Identical local blog IDs must not collide across isolated networks');
+    assert_true($isolated_site_1 !== 1, 'Isolated queue identities must not collide with ordinary root blog IDs');
+
+    $isolated_payload = new Job_Payload([
+        'site_id'             => $isolated_site_1,
+        'isolated_network_id' => 49,
+        'local_site_id'       => 1,
+        'site_url'            => 'https://isolated.example.test',
+        'hook'                => 'isolated_hook',
+        'timestamp'           => 2147483647,
+    ]);
+    assert_true($isolated_payload->routes_to_isolated_network(49), 'Isolated payload metadata must validate against its composite queue identity');
+    assert_same(49, json_decode($isolated_payload->to_json(), true)['isolated_network_id'] ?? null, 'Isolated routing metadata must survive queue serialization');
+    try {
+        new Job_Payload([
+            'site_id'             => $isolated_site_1,
+            'isolated_network_id' => 50,
+            'local_site_id'       => 1,
+        ]);
+        throw new RuntimeException('Mismatched isolated payload metadata must fail closed');
+    } catch (InvalidArgumentException $exception) {
+        assert_true(str_contains($exception->getMessage(), 'does not match'), 'Mismatched isolated payload metadata must report its identity failure');
+    }
+
+    assert_true(false !== file_put_contents(WP_CONTENT_DIR . '/network-registry.data.json', json_encode([
+        'networks' => [
+            49 => ['tier' => 'isolated', 'status' => 'active', 'domain' => 'isolated.example.test'],
+            50 => ['tier' => 'shared', 'status' => 'active', 'domain' => 'shared.example.test'],
+            51 => ['tier' => 'isolated', 'status' => 'inactive', 'domain' => 'inactive.example.test'],
+            52 => ['tier' => 'isolated', 'status' => 'active'],
+        ],
+    ])), 'Network registry fixture must be writable');
+    $registry_worker = new Worker_Process(__FILE__, 'example.test', __FILE__);
+    assert_same([49], array_keys(invoke_private($registry_worker, 'isolated_network_entries')), 'Only active, routable isolated network entries may be scanned');
+    assert_true(false !== file_put_contents(WP_CONTENT_DIR . '/network-registry.data.json', json_encode([
+        'networks' => [
+            49 => ['tier' => 'isolated', 'status' => 'active', 'domain' => 'isolated.example.test'],
+            53 => ['tier' => 'isolated', 'status' => 'active', 'domains' => ['new-isolated.example.test']],
+        ],
+    ])), 'Updated network registry fixture must be writable');
+    assert_same([49, 53], array_keys(invoke_private($registry_worker, 'isolated_network_entries')), 'Every full-rescan lookup must re-read newly registered isolated networks');
+    assert_true(false !== file_put_contents(WP_CONTENT_DIR . '/network-registry.data.json', json_encode([
+        'networks' => [
+            12 => ['tier' => 'isolated', 'status' => 'active', 'domain' => 'isolated.example.test'],
+        ],
+    ])), 'Final network registry fixture must be writable');
+
+    $isolated_scan_fixture = tempnam(sys_get_temp_dir(), 'qw-isolated-scan-');
+    assert_true(false !== $isolated_scan_fixture, 'Isolated scan fixture must be created');
+    $mismatched_scan_output = json_encode([[
+        'site_id'             => Job_Payload::isolated_site_id(50, 1),
+        'isolated_network_id' => 50,
+        'local_site_id'       => 1,
+        'site_url'            => 'https://wrong-isolated.example.test',
+        'hook'                => 'wrong_isolated_hook',
+        'timestamp'           => 2147483647,
+    ]]);
+    assert_true(false !== file_put_contents(
+        $isolated_scan_fixture,
+        '<?php fwrite(STDOUT, ' . var_export($mismatched_scan_output, true) . ');'
+    ), 'Mismatched isolated scan fixture must be writable');
+    $isolated_worker = new Worker_Process(__FILE__, 'example.test', __FILE__, $isolated_scan_fixture);
+    \Workerman\Worker::$logs = [];
+    \Workerman\Timer::$delays = [];
+    invoke_private($isolated_worker, 'rescan_isolated_network_jobs', [49, ['domain' => 'isolated.example.test']]);
+    assert_same([], \Workerman\Timer::$delays, 'Scanner payloads routed to another isolated network must not be scheduled');
+    assert_true(
+        str_contains(implode("\n", \Workerman\Worker::$logs), 'did not route to the expected isolated network'),
+        'Rejected isolated scanner payloads must identify the route mismatch'
+    );
+
+    $valid_scan_output = json_encode([json_decode($isolated_payload->to_json(), true)]);
+    assert_true(false !== file_put_contents(
+        $isolated_scan_fixture,
+        '<?php fwrite(STDOUT, ' . var_export($valid_scan_output, true) . ');'
+    ), 'Valid isolated scan fixture must be writable');
+    \Workerman\Worker::$logs = [];
+    \Workerman\Timer::$delays = [];
+    invoke_private($isolated_worker, 'rescan_isolated_network_jobs', [49, ['domain' => 'isolated.example.test']]);
+    assert_same(1, count(\Workerman\Timer::$delays), 'Valid isolated scanner payloads must be scheduled');
+
+    $proxy_network_payload = new Job_Payload([
+        'site_id'             => Job_Payload::isolated_site_id(12, 1),
+        'isolated_network_id' => 12,
+        'local_site_id'       => 1,
+        'site_url'            => 'https://isolated.example.test',
+        'hook'                => 'proxy_network_hook',
+        'timestamp'           => 2147483647,
+    ]);
+    $proxy_scan_output = json_encode([json_decode($proxy_network_payload->to_json(), true)]);
+    assert_true(false !== file_put_contents(
+        $isolated_scan_fixture,
+        '<?php fwrite(STDOUT, ' . var_export($proxy_scan_output, true) . ');'
+    ), 'Proxy-network scan fixture must be writable');
+    $GLOBALS['test_sites'] = [1, 175];
+    $GLOBALS['test_site_network_ids'] = [
+        1   => 1,
+        175 => 12,
+    ];
+    $GLOBALS['test_switched_blogs'] = [];
+    $GLOBALS['test_crons'] = [];
+    \Workerman\Timer::$delays = [];
+    $root_scan_worker = new Worker_Process(__FILE__, 'example.test', __FILE__, $isolated_scan_fixture);
+    invoke_private($root_scan_worker, 'rescan_all_jobs');
+    assert_true(!in_array(175, $GLOBALS['test_switched_blogs'], true), 'Root scanning must skip proxy blog 175 because it belongs to isolated network 12');
+    assert_same(1, count(\Workerman\Timer::$delays), 'A root full rescan must include the isolated tenant scanner result');
+    $GLOBALS['test_sites'] = [1];
+    $GLOBALS['test_site_network_ids'] = [];
+    assert_true(unlink($isolated_scan_fixture), 'Isolated scan fixture must be removed');
+    \Workerman\Timer::$delays = [];
+
+    assert_true(
+        str_contains($scan_script, "defined('WU_MT_LEGACY_ISOLATED_NETWORK')")
+            && str_contains($scan_script, "get_sites(['number' => 0, 'fields' => 'ids'])")
+            && str_contains($scan_script, 'qw_scan_current_site_jobs()'),
+        'Isolated scanner bootstrap must validate the routed network and enumerate every tenant-local site'
+    );
+    assert_true(
+        str_contains($executor_entrypoint, 'routes_to_isolated_network($isolated_network_id)')
+            && str_contains($executor_entrypoint, "defined('WU_MT_LEGACY_ISOLATED_NETWORK')"),
+        'Executor bootstrap must validate isolated queue identities and the routed tenant network'
+    );
+
     $GLOBALS['test_current_blog_id'] = 49;
     $GLOBALS['test_ms_switched'] = true;
     $GLOBALS['test_site_url'] = 'https://mapped.example.test/wp';
@@ -1103,6 +1241,46 @@ namespace {
         assert_true(str_contains($cleanup_query, 'ORDER BY completed_at ASC'), 'Job log cleanup must delete the oldest rows first');
         assert_true(str_contains($cleanup_query, 'LIMIT 10000'), 'Job log cleanup must bound each delete statement');
     }
+
+    assert_same(false, Socket_Client::filter_wp_cron_status_override(false), 'Cron health override must preserve a prior non-null decision');
+    putenv('QUEUE_WORKER_SOCKET_PATH=' . sys_get_temp_dir() . '/qw-missing-socket-' . getmypid());
+    assert_same(null, Socket_Client::filter_wp_cron_status_override(null), 'Cron health override must retain the null sentinel when no worker is available');
+    if (function_exists('pcntl_fork')) {
+        $status_socket = sys_get_temp_dir() . '/qw-status-' . getmypid() . '.sock';
+        @unlink($status_socket);
+        $status_server = stream_socket_server('unix://' . $status_socket, $status_errno, $status_error);
+        assert_true(is_resource($status_server), 'Cron health status fixture must create a Unix socket: ' . $status_error);
+        $status_pid = pcntl_fork();
+        assert_true($status_pid >= 0, 'Cron health status fixture must fork');
+        if ($status_pid === 0) {
+            $status_connection = stream_socket_accept($status_server, 2);
+            if (is_resource($status_connection)) {
+                fgets($status_connection);
+                fwrite($status_connection, json_encode(['ready' => true]) . "\n");
+                fclose($status_connection);
+            }
+            fclose($status_server);
+            exit(0);
+        }
+        fclose($status_server);
+        putenv('QUEUE_WORKER_SOCKET_PATH=' . $status_socket);
+        assert_same(true, Socket_Client::filter_wp_cron_status_override(null), 'A ready Socket_Client worker must report intentional external cron as healthy');
+        pcntl_waitpid($status_pid, $status_result);
+        assert_true(unlink($status_socket), 'Cron health status fixture socket must be removed');
+    }
+    putenv('QUEUE_WORKER_SOCKET_PATH');
+
+    define('WU_MT_LEGACY_ISOLATED_NETWORK', 49);
+    $GLOBALS['test_current_blog_id'] = 2;
+    $live_isolated_payload = Job_Payload::from_cron_event((object) [
+        'hook'      => 'live_isolated_hook',
+        'args'      => [],
+        'timestamp' => 2147483647,
+        'schedule'  => '',
+    ]);
+    assert_same(Job_Payload::isolated_site_id(49, 2), $live_isolated_payload->site_id, 'Live request interception must use the collision-safe isolated queue identity');
+    assert_same(49, $live_isolated_payload->isolated_network_id, 'Live request payloads must carry their isolated network route');
+    assert_same(2, $live_isolated_payload->local_site_id, 'Live request payloads must carry their tenant-local blog route');
 
     echo "Regression tests passed.\n";
 }

--- a/the-perfect-wp-cron.php
+++ b/the-perfect-wp-cron.php
@@ -35,6 +35,7 @@ if ($queue_worker_running && !$job_executor_running) {
     return;
 }
 
+add_filter('wu_wp_cron_status_override', ['QueueWorker\\Socket_Client', 'filter_wp_cron_status_override']);
 add_action('init', ['QueueWorker\\Cron_Interceptor', 'register']);
 QueueWorker\Action_Scheduler_Bridge::register_stored_action_hook();
 add_action('action_scheduler_init', ['QueueWorker\\Action_Scheduler_Bridge', 'register']);


### PR DESCRIPTION
## Summary
- discover active isolated networks from the multi-tenancy network registry
- scan each tenant-local site with collision-free composite queue identities
- validate network, site, domain, and batch routing before executing jobs
- expose healthy external scheduler status to Ultimate Multisite
- initialize pnpm before setup-node cache restoration so the required asset check can run

## Problem
The queue worker scanned control-plane sites and sovereign site-registry entries, but not legacy isolated-network databases. Cron events in those tenant databases could therefore remain overdue indefinitely. The existing asset workflow also requested pnpm caching before pnpm was installed, causing every PR build to stop during setup-node.

## Verification
- `php -l` on all changed PHP files
- `php tests/regression.php`
- `git diff --check`
- GitHub Actions asset-build rerun after the workflow ordering fix

The regression suite covers isolated-network discovery, proxy skipping, composite identity round trips, tenant-local site scans, route validation, and external scheduler status.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for isolated networks, including routing, scanning, and job processing across network sites.
  * Added more reliable worker-based WP-Cron health status reporting.
  * Enhanced registry scanning for isolated and sovereign environments.

* **Bug Fixes**
  * Added validation to prevent jobs with invalid or mismatched routing metadata from executing.
  * Improved handling of network and site identities during rescans and scheduled processing.

* **Tests**
  * Expanded regression coverage for isolated-network routing, cron health, rescans, and worker failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->