### PR TITLE
fix: bootstrap cron scanner before site autoload

### DIFF
--- a/bin/scan-cron.php
+++ b/bin/scan-cron.php
@@ -36,6 +36,16 @@ $plugin_autoload = dirname(__DIR__) . '/vendor/autoload.php';
 if (file_exists($plugin_autoload)) {
     require_once $plugin_autoload;
 }
+if (!class_exists('QueueWorker\\Bootstrap')) {
+    require_once dirname(__DIR__) . '/src/class-bootstrap.php';
+}
+
+// Discover WordPress before loading the site Composer autoloader. Bedrock's
+// autoloaded plugin files may exit when ABSPATH has not been defined yet.
+$wp_load = QueueWorker\Bootstrap::discover_wp_load(__DIR__);
+if (!defined('ABSPATH')) {
+    define('ABSPATH', rtrim(dirname($wp_load), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR);
+}
 
 $site_autoload = null;
 $search = dirname(__DIR__);
@@ -62,7 +72,6 @@ use QueueWorker\Job_Payload;
 
 $site_root = $site_autoload ? dirname($site_autoload, 2) : dirname(__DIR__);
 Bootstrap::load_dotenv($site_root);
-$wp_load = Bootstrap::discover_wp_load(__DIR__);
 
 $domain = parse_url($payload['site_url'] ?? '', PHP_URL_HOST);
 if (!$domain) {

--- a/tests/regression.php
+++ b/tests/regression.php
@@ -152,6 +152,20 @@ namespace {
         'Executor subprocesses must identify themselves before WordPress loads'
     );
 
+    $scanner_entrypoint = file_get_contents(__DIR__ . '/../bin/scan-cron.php');
+    assert_true(is_string($scanner_entrypoint), 'Scanner entrypoint must be readable');
+    $scanner_discovery = strpos($scanner_entrypoint, 'QueueWorker\\Bootstrap::discover_wp_load');
+    $scanner_abspath = strpos($scanner_entrypoint, "define('ABSPATH'");
+    $scanner_site_autoload = strpos($scanner_entrypoint, 'require_once $site_autoload;');
+    assert_true(
+        $scanner_discovery !== false
+            && $scanner_abspath !== false
+            && $scanner_site_autoload !== false
+            && $scanner_discovery < $scanner_site_autoload
+            && $scanner_abspath < $scanner_site_autoload,
+        'Scanner must discover WordPress and define ABSPATH before loading the site autoloader'
+    );
+
     $plugin_entrypoint = file_get_contents(__DIR__ . '/../the-perfect-wp-cron.php');
     assert_true(is_string($plugin_entrypoint), 'Plugin entrypoint must be readable');
     assert_true(


### PR DESCRIPTION
## Summary

- discover WordPress and define `ABSPATH` before loading the Bedrock site Composer autoloader in `bin/scan-cron.php`
- retain the direct Bootstrap fallback used by dist installs
- add a regression assertion that locks in the required bootstrap order

## Production evidence

The deployed scanner returned a valid empty payload for both the host network and a representative sovereign tenant, while WP-CLI against the same tenant reported 19 cron events and registered Domain Seller renewal and transfer callbacks. Loading the site autoloader before `ABSPATH` caused a partial Bedrock plugin bootstrap.

## Files

- `bin/scan-cron.php`: align scanner bootstrap ordering with the worker and executor entrypoints
- `tests/regression.php`: enforce discovery and `ABSPATH` definition before site autoload

## Verification

- `php -l bin/scan-cron.php`
- `php -l tests/regression.php`
- `php tests/regression.php`
- `git diff --check`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.231 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol
