### PR TITLE
fix: wait for committed scheduler actions

### DIFF
--- a/src/class-job-executor.php
+++ b/src/class-job-executor.php
@@ -281,8 +281,48 @@ class Job_Executor
         if (!$action_id || !class_exists('ActionScheduler_QueueRunner')) {
             throw new \RuntimeException('ActionScheduler not available or missing action_id');
         }
+
+        if (!$this->wait_for_action_scheduler_action($action_id)) {
+            return;
+        }
+
         $runner = \ActionScheduler_QueueRunner::instance();
         $runner->process_action($action_id);
+    }
+
+    /**
+     * Wait briefly for an action created inside another request's transaction.
+     *
+     * action_scheduler_stored_action fires before the surrounding transaction
+     * commits. A socket-triggered executor can therefore start while the action
+     * row is still invisible to its database connection. Passing that ID to the
+     * queue runner marks the action failed before its callback can run. A bounded
+     * wait preserves immediate dispatch; if the row remains unavailable, the
+     * regular scanner can pick it up after the transaction commits.
+     */
+    private function wait_for_action_scheduler_action(
+        int $action_id,
+        int $max_attempts = 20,
+        int $delay_microseconds = 250000
+    ): bool {
+        $store = \ActionScheduler::store();
+        $max_attempts = max(1, $max_attempts);
+
+        for ($attempt = 1; $attempt <= $max_attempts; $attempt++) {
+            try {
+                return \ActionScheduler_Store::STATUS_PENDING === $store->get_status($action_id);
+            } catch (\InvalidArgumentException $e) {
+                if ($attempt === $max_attempts) {
+                    return false;
+                }
+
+                if ($delay_microseconds > 0) {
+                    usleep($delay_microseconds);
+                }
+            }
+        }
+
+        return false;
     }
 
     private function set_alarm(): void

--- a/tests/regression.php
+++ b/tests/regression.php
@@ -98,6 +98,55 @@ namespace {
             return $this->message;
         }
     }
+
+    class ActionScheduler_Store
+    {
+        public const STATUS_PENDING = 'pending';
+    }
+
+    class Test_ActionScheduler_Store
+    {
+        public array $statuses = [];
+        public array $action_ids = [];
+
+        public function get_status(int $action_id): string
+        {
+            $this->action_ids[] = $action_id;
+            $status = array_shift($this->statuses);
+
+            if ($status instanceof Throwable) {
+                throw $status;
+            }
+
+            return (string) $status;
+        }
+    }
+
+    class ActionScheduler
+    {
+        public static ?Test_ActionScheduler_Store $store = null;
+
+        public static function store(): Test_ActionScheduler_Store
+        {
+            return self::$store ??= new Test_ActionScheduler_Store();
+        }
+    }
+
+    class ActionScheduler_QueueRunner
+    {
+        public static ?self $runner = null;
+        public array $processed_action_ids = [];
+
+        public static function instance(): self
+        {
+            return self::$runner ??= new self();
+        }
+
+        public function process_action(int $action_id): void
+        {
+            $this->processed_action_ids[] = $action_id;
+        }
+    }
 }
 
 namespace {
@@ -920,6 +969,36 @@ namespace {
     assert_same(0.001, \Workerman\Timer::$delays[0] ?? null, 'Due Action Scheduler payloads must use a positive near-immediate timer delay');
 
     $executor = new QueueWorker\Job_Executor(1);
+    ActionScheduler::$store = new Test_ActionScheduler_Store();
+    ActionScheduler::$store->statuses = [
+        new InvalidArgumentException('Action is not committed yet'),
+        new InvalidArgumentException('Action is not committed yet'),
+        ActionScheduler_Store::STATUS_PENDING,
+    ];
+    assert_same(
+        true,
+        invoke_private($executor, 'wait_for_action_scheduler_action', [44, 3, 0]),
+        'An Action Scheduler row hidden by another request transaction must be retried until it becomes visible'
+    );
+    assert_same([44, 44, 44], ActionScheduler::$store->action_ids, 'Transaction visibility retries must check the same durable action ID');
+
+    ActionScheduler::$store = new Test_ActionScheduler_Store();
+    ActionScheduler::$store->statuses = [ActionScheduler_Store::STATUS_PENDING];
+    ActionScheduler_QueueRunner::$runner = new ActionScheduler_QueueRunner();
+    invoke_private($executor, 'execute_action_scheduler', [['action_id' => 45]]);
+    assert_same([45], ActionScheduler_QueueRunner::$runner->processed_action_ids, 'A visible pending Action Scheduler action must run normally');
+
+    ActionScheduler::$store = new Test_ActionScheduler_Store();
+    ActionScheduler::$store->statuses = [
+        new InvalidArgumentException('Missing action'),
+        new InvalidArgumentException('Missing action'),
+    ];
+    assert_same(
+        false,
+        invoke_private($executor, 'wait_for_action_scheduler_action', [46, 2, 0]),
+        'A still-invisible action must remain pending for the scanner instead of being passed to the queue runner'
+    );
+
     $stale_job = [
         'hook'      => 'stale_one_shot_hook',
         'args'      => ['a' => 1],


### PR DESCRIPTION
## Summary

- wait briefly for socket-triggered Action Scheduler rows that are still hidden by a caller transaction
- skip the queue runner when a row remains unavailable so the normal scanner can process it after commit
- cover transient visibility, normal pending execution, and bounded timeout behavior

## Production evidence

A checkout-created pending-site action was dispatched before its surrounding database transaction committed. The executor started about 1.2 seconds later; Action Scheduler reported `Invalid action ID. No status found.` and failed the action without invoking its callback. Retrying the same pending membership after commit completed successfully and created the requested site.

## Verification

- `php -l src/class-job-executor.php`
- `php -l tests/regression.php`
- `php tests/regression.php`
- `git diff --check`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.232 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scheduled action execution when action records are temporarily unavailable.
  - The system now retries briefly until an action becomes ready, rather than processing it prematurely.
  - Actions that remain unavailable are safely skipped and retained for a later scan, preventing missed or incorrectly processed tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->