### PR TITLE
fix: use Node 24 GitHub Actions

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
Resolves #63. Updates pnpm/action-setup and actions/setup-node to Node 24-compatible major versions. Verified action metadata and git diff --check.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.233 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra
