### PR TITLE
GH#67: align scheduled-time wording

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Stable tag: 1.0.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Event-loop job queue for WordPress. Executes WP Cron and Action Scheduler jobs at exact scheduled times with zero polling using Workerman.
+Event-loop job queue for WordPress. Executes WP Cron and Action Scheduler jobs at scheduled times with zero polling using Workerman.
 
 == Description ==
 
-Event-loop job queue for WordPress. Executes WP Cron and Action Scheduler jobs at exact scheduled times with zero polling using Workerman.
+Event-loop job queue for WordPress. Executes WP Cron and Action Scheduler jobs at scheduled times with zero polling using Workerman.


### PR DESCRIPTION
## Summary

Updated both plugin readme descriptions to avoid claiming exact job timing.

## Files Changed

readme.txt

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — composer test:regression; git diff --check

Resolves #67


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.275 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 2m and 42,978 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README tagline and description for clearer wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->